### PR TITLE
Temporarily disable service worker

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -125,19 +125,20 @@ export default {
 		onwarn,
 	},
 
-	serviceworker: {
-		input: config.serviceworker.input(),
-		output: config.serviceworker.output(),
-		plugins: [
-			resolve(),
-			replace({
-				'process.browser': true,
-				'process.env.NODE_ENV': JSON.stringify(mode)
-			}),
-			commonjs(),
-			!dev && terser()
-		],
+	// temporarily disabling the service worker until I can clean up the static folder to reduce unnecessary requests
+	// serviceworker: {
+	// 	input: config.serviceworker.input(),
+	// 	output: config.serviceworker.output(),
+	// 	plugins: [
+	// 		resolve(),
+	// 		replace({
+	// 			'process.browser': true,
+	// 			'process.env.NODE_ENV': JSON.stringify(mode)
+	// 		}),
+	// 		commonjs(),
+	// 		!dev && terser()
+	// 	],
 
-		onwarn,
-	}
+	// 	onwarn,
+	// }
 };

--- a/src/template.html
+++ b/src/template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
 	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width,initial-scale=1.0'>


### PR DESCRIPTION
Realized that the service worker was requesting ALL of the static assets, resulting in 180+MB of mostly unnecessary downloads. Going to kill it until I have time to fine tune it to only download what the site actually needs to run offline.