### PR TITLE
fix height and width styles on img tag

### DIFF
--- a/src/components/ResponsivePicture.svelte
+++ b/src/components/ResponsivePicture.svelte
@@ -71,8 +71,6 @@
 
 	img {
 		display: block;
-		width: 100%;
-		height: 100%;
 	}
 
 	.contain,
@@ -92,7 +90,7 @@
 	}
 
 	/* only do this if object-fit is supported, so image doesn't get oddly cropped */
-	@supports (object-fit: scale-down) {
+	@supports (object-fit: contain) {
 		.fill {
 			position: absolute;
 			top: 0;


### PR DESCRIPTION
was causing distortion in contexts where object-fit isn't used

## Tasks
- [Fixed crush blog cover images...](https://www.notion.so/jayperryworks/Fixed-crushed-blog-cover-images-in-Safari-3ec4711f9977447cb2126ad5be3be22b)