### PR TITLE
Fix Safari bug with header logo

### DIFF
--- a/src/components/MainNav.svelte
+++ b/src/components/MainNav.svelte
@@ -122,6 +122,7 @@
   .logo {
     border: none;
     display: block;
+    max-width: 2.5rem;
   }
 
   .nav-button {


### PR DESCRIPTION
so safari doesn't misinterpret the svg's width/height attr's