### PR TITLE
Mobile spine and borders

### DIFF
--- a/scripts/css/borders.js
+++ b/scripts/css/borders.js
@@ -1,11 +1,11 @@
-const { borders, type, spacing, breakpoints } = require('../../content/design-tokens.js')
-const { helpers: theme } = require('./color.js')
-const { helpers: spacingHelpers } = require('./spacing.js')
+const { borders, type, spacing, breakpoints } = require('../../content/design-tokens.js');
+const { helpers: theme } = require('./color.js');
+const { helpers: spacingHelpers } = require('./spacing.js');
 
 const borderSeamSelectors = {
 	top: 'before',
 	bottom: 'after'
-}
+};
 
 function add ({
 	side = 'all',
@@ -13,7 +13,7 @@ function add ({
 	style = 'dashed'
 } = {}) {
 	return `
-		border${side === 'all' ? '' : `-${side}`}: ${borders.widths.default}px ${style} ${theme.getValue('border')};
+		border${side === 'all' ? '' : `-${side}`}: ${borders.widths.default}px ${style} ${theme.getHSLValue('border')};
 		border${side === 'all' ? '' : `-${side}`}: ${borders.widths.default}px ${style} ${theme.getCustomProperty('border')};
 	`
 }
@@ -74,7 +74,7 @@ module.exports = {
 			border-left-style: solid;
 		}
 
-		/* 
+		/*
 			"Seam" effect border
 			-> use an svg pattern to create a styled border that looks like stitching
 		*/
@@ -86,7 +86,7 @@ module.exports = {
 
 			@supports(
 				border-image:
-					url('whatever.svg')
+					url('${borders.seam.image}')
 					${borders.seam.marker.h} 0 0 ${borders.seam.marker.w}
 					repeat
 			) {
@@ -111,13 +111,18 @@ module.exports = {
 					z-index: 3;
 				}
 
-				${Object.keys(spacing.outside).map(screen => `
-					@media screen and (max-width: ${breakpoints.sizes[screen]}${breakpoints.unit}) {
-						.border-seam-${side}::${borderSeamSelectors[side]} {
-							right: ${spacingHelpers.get(spacing.outside[screen])};
-						}
+				${Object.keys(spacing.outside).map((screen) => {
+					if (screen != 'default') {
+						return `
+							@media screen and (max-width: ${breakpoints.sizes[screen]}${breakpoints.unit}) {
+								.border-seam-${side}::${borderSeamSelectors[side]} {
+									right: ${spacingHelpers.get(spacing.outside[screen])};
+								}
+							}
+						`;
 					}
-				`).join('')}
+					return;
+				}).join('')}
 			}
 		`).join('')}
 	`

--- a/scripts/css/color.js
+++ b/scripts/css/color.js
@@ -11,6 +11,10 @@ function getValue (role, theme = 'default') {
 	return color.themes[theme][role]
 }
 
+function getHSLValue (role, theme = 'default') {
+	return hsl(color.themes[theme][role]);
+}
+
 function getCustomProperty (role, theme = 'default') {
 	const variables = Object.keys(color.themes[theme][role]).map(channel => `
 		var(--color-${role}-${channel})
@@ -25,7 +29,7 @@ function setCustomProperty (role, { h, s, l, a }) {
 		--color-${role}-s: ${s}%;
 		--color-${role}-l: ${l}%;
 		${a ? `--color-${role}-a: ${a};` : ''}
-		
+
 		--color-${role}: hsl(
 			var(--color-${role}-h),
 			var(--color-${role}-s),
@@ -52,6 +56,7 @@ module.exports = {
 	name: 'Color',
 	helpers: {
 		getValue,
+		getHSLValue,
 		getCustomProperty,
 		setCustomProperty,
 		add

--- a/scripts/css/color.js
+++ b/scripts/css/color.js
@@ -1,7 +1,7 @@
 const { color } = require('../../content/design-tokens.js')
 
 function hsl (color) {
-  if (color.a && color.a !== 1) {
+  if (color?.a < 1) {
   	return `hsl(${color.h}, ${color.s}%, ${color.l}%, ${color.a})`
   }
   return `hsl(${color.h}, ${color.s}%, ${color.l}%)`

--- a/scripts/css/specialEffects.js
+++ b/scripts/css/specialEffects.js
@@ -4,7 +4,7 @@ module.exports = {
 	name: 'Special effects',
 	utilities: `
 		.shadow {
-			box-shadow: 0 0 0.5rem ${color.getValue('shadow')};
+			box-shadow: 0 0 0.5rem ${color.getHSLValue('shadow')};
 			box-shadow: 0 0 0.5rem var(--color-shadow);
 		}
 	`

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -8,6 +8,7 @@
 
 <div
   id="spine-wrapper"
+	class="overflow-hidden"
   class:loading="{$preloading}"
 >
   <div id="main-wrapper">

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -3,17 +3,7 @@
   import color from 'css/color.js'
   import MainFooter from '@/components/MainFooter.svelte'
 
-  const { getValue: getColorValue } = color.helpers
-
   const { preloading } = stores()
-
-  // export let highlightColor = getColorValue('highlight')
-
-  // $: style = `
-  //   --color-highlight-h: ${highlightColor.h};
-  //   --color-highlight-s: ${highlightColor.s}%;
-  //   --color-highlight-l: ${highlightColor.l}%;
-  // `
 </script>
 
 <div
@@ -31,16 +21,16 @@
   #spine-wrapper {
     --spine-color: hsl(
       var(--color-highlight-h),
-      var(--color-highlight-s), 
+      var(--color-highlight-s),
       var(--color-highlight-l)
     );
     --spine-color-tint: hsl(
       var(--color-highlight-h),
-      var(--color-highlight-s), 
+      var(--color-highlight-s),
       calc(var(--color-highlight-l) + 10%)
     );
     --spine-stripe-size: 30px;
-    --spine-width: 0.6rem;
+    --spine-width: 0.35rem;
 
     padding-left: var(--spine-width);
     position: relative;
@@ -79,16 +69,22 @@
     }
   }
 
+	@media screen and (min-width: 42em) {
+		#spine-wrapper {
+			--spine-width: 0.6rem;
+		}
+	}
+
   #main-wrapper {
     position: relative;
   }
-  
+
   @supports (display: flex) {
     body {
       display: flex;
       flex-direction: column;
     }
-    
+
     #sapper,
     #spine-wrapper,
     #main-wrapper {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -44,7 +44,7 @@
 
 <MainNav segment="/" overlay />
 
-<main class="fill-vertical | hide-overflow">
+<main class="fill-vertical">
 
 	<!-- intro -->
 	<Panel
@@ -64,7 +64,7 @@
 				<Wrapper width="wide" centered={false}>
 					<h1 class="type-leading-xtight">{@html intro.headline}</h1>
 				</Wrapper>
-				<Wrapper 
+				<Wrapper
 					centered="{false}"
 					class="type-scale-delta type-heading type-leading-default | padding-top padding-bottom-wide"
 				>
@@ -122,7 +122,7 @@
 						class="margin-y-flow-wide"
 						centered="{false}"
 					>
-						
+
 						{#if pictures.blurb}
 							<Passage html="{pictures.blurb}" class="type-scale-delta type-heading type-leading-default"/>
 						{/if}
@@ -180,7 +180,7 @@
 						class="margin-y-flow-wide"
 						centered="{false}"
 					>
-						
+
 						{#if design.blurb}
 							<Passage html="{design.blurb}" class="type-scale-delta type-heading type-leading-default"/>
 						{/if}


### PR DESCRIPTION
## Description
- Fix a bug where color defaults in CSS were rendering as `[Object Object]` - added `getHSLValue()` function to output the correct string instead of the raw object
- Make the 'spine' on the left narrow on mobile phone screens
- Fix overflow/z-index issues on 'seam' border effects on homepage

## Tasks
- [Fallback colors](https://www.notion.so/jayperryworks/Fallback-colors-in-global-css-are-printing-as-Object-00e39b8a65214a1c9a7457fd0f2fb084)
- [Make spine narrower](https://www.notion.so/jayperryworks/Make-spine-and-left-margin-narrower-on-mobile-a01fa2c038da4bb3a77aff6374eab6f4)
- [Panel borders don't work in mobile safari](https://www.notion.so/jayperryworks/Panel-borders-don-t-work-in-mobile-safari-22957bd3d7e740df921488e76d1fe505)