### PR TITLE
Sidenote spacing

### DIFF
--- a/src/components/blocks/Passage.astro
+++ b/src/components/blocks/Passage.astro
@@ -40,43 +40,52 @@ let sidenoteCount = 0;
 // --- functions
 // render special elements from Prismic text
 function htmlSerializer(type, element, content, children): string {
-	if (element.data?.label === 'note') {
-		// remove the fallback parentheses around the label text.
-		let note = children.toString().replace('(', '').replace(')', '').trim();
+	// custom labels
+	if (element.data) {
+		const { label } = element.data;
 
-		// add a period at the end of the note text, if there isn't one.
-		console.log('hello')
-		console.log(note.slice(-1))
-		if (note.slice(-1) !== '.') note = note.concat('.');
+		if (label === 'note') {
+			// remove the fallback parentheses around the label text.
+			let note = children.toString().replace('(', '').replace(')', '').trim();
 
-		// add to sidenote count so each gets a unique number
-		sidenoteCount += 1;
+			// add a period at the end of the note text, if there isn't one.
+			if (note.slice(-1) !== '.') note = note.concat('.');
 
-		return `
-			<span class="sidenote">
-				<input
-					aria-label="Show the sidenote"
-					class="sidenote-input"
-					id="sidenote-input-${sidenoteCount}"
-					type="checkbox"
-				>
-					<label
-						aria-describedby="${sidenoteCount}"
-						class="sidenote-label"
-						for="sidenote-input-${sidenoteCount}"
-						tabindex="0"
-					>${sidenoteCount}</label>
-				</input>
-				<small
-					class="sidenote-content ${sidenoteCount % 2 === 0 ? 'left' : 'right'}"
-					id="${sidenoteCount}"
-				>
-					<span class="sidenote-parenthesis">(Note: </span>
-					<span class="sidenote-text">${sentenceCase(note)}</span>
-					<span class="sidenote-parenthesis">)</span>
-				</small>
-			</span>
-		`;
+			// add to sidenote count so each gets a unique number
+			sidenoteCount += 1;
+
+			return `
+				<span class="sidenote">
+					<input
+						aria-label="Show the sidenote"
+						class="sidenote-input"
+						id="sidenote-input-${sidenoteCount}"
+						type="checkbox"
+					>
+						<label
+							aria-describedby="${sidenoteCount}"
+							class="sidenote-label"
+							for="sidenote-input-${sidenoteCount}"
+							tabindex="0"
+						>${sidenoteCount}</label>
+					</input>
+					<small
+						class="sidenote-content ${sidenoteCount % 2 === 0 ? 'left' : 'right'}"
+						id="${sidenoteCount}"
+					>
+						<span class="sidenote-parenthesis">(Note: </span>
+						<span class="sidenote-text">${sentenceCase(note)}</span>
+						<span class="sidenote-parenthesis">)</span>
+					</small>
+				</span>
+			`;
+		}
+
+		if (label === 'inline code') {
+			return `
+				<code>${children.toString()}</code>
+			`;
+		}
 	}
 
 	return null;

--- a/src/components/blocks/Passage.astro
+++ b/src/components/blocks/Passage.astro
@@ -42,10 +42,12 @@ let sidenoteCount = 0;
 function htmlSerializer(type, element, content, children): string {
 	if (element.data?.label === 'note') {
 		// remove the fallback parentheses around the label text.
-		let label = children.toString().replace('(', '').replace(')', '');
+		let note = children.toString().replace('(', '').replace(')', '').trim();
 
-		// add a period at the end of the label text, if there isn't one.
-		if (label.charAt(label.length - 1) !== '.') label = label.concat('.');
+		// add a period at the end of the note text, if there isn't one.
+		console.log('hello')
+		console.log(note.slice(-1))
+		if (note.slice(-1) !== '.') note = note.concat('.');
 
 		// add to sidenote count so each gets a unique number
 		sidenoteCount += 1;
@@ -70,7 +72,7 @@ function htmlSerializer(type, element, content, children): string {
 					id="${sidenoteCount}"
 				>
 					<span class="sidenote-parenthesis">(Note: </span>
-					<span class="sidenote-text">${sentenceCase(label)}</span>
+					<span class="sidenote-text">${sentenceCase(note)}</span>
 					<span class="sidenote-parenthesis">)</span>
 				</small>
 			</span>
@@ -147,6 +149,7 @@ function htmlSerializer(type, element, content, children): string {
 		font-size: 0.6em;
 		line-height: inherit;
 		padding-inline: 0.5rem;
+		margin-inline: 0.25em;
 		position: relative;
 		text-align: center;
 		transition: color 0.25s ease, border-color 0.25s ease;

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -127,10 +127,13 @@ const {
 		</ul>
 		<nav>
 			<ReadNextLink
-				eyebrow="More blog posts:"
-				title="Archive"
+				eyebrowSize="delta"
 				link="/blog/page/1"
-			/>
+				titleSize="beta"
+			>
+				<Fragment slot="eyebrow">More blog posts:</Fragment>
+				<Fragment slot="title">Archive</Fragment>
+			</ReadNextLink>
 		</nav>
 	</div>
 </Layout>

--- a/src/styles/base/type.css
+++ b/src/styles/base/type.css
@@ -146,3 +146,12 @@ strong {
 em {
 	font-style: italic;
 }
+
+code {
+	background-color: var(--color-well);
+	border-radius: 0.2em;
+	display: inline-block;
+	font-family: "Menlo", "Monaco", "Consolas", "Lucida Console", monospace;
+	font-size: 0.75em;
+	padding: 0 0.25em;
+}


### PR DESCRIPTION
## Description
- Fixed a bug where sidenote labels don’t have enough space around them, and an extra period is added to some notes that already have one.
- Added formatting for the `inline code` label in Prismic
- Fixed a bug where the ‘read more’ link shows up empty on tag pages

## Tasks
- [Fix sidenote bugs](https://todoist.com/showTask?id=6237214013)
- [Add formatting for code label](https://todoist.com/showTask?id=6213215379)