### PR TITLE
Mastodon verification link in the footer

### DIFF
--- a/src/components/navigation/MainFooter.astro
+++ b/src/components/navigation/MainFooter.astro
@@ -23,6 +23,7 @@ import { LinkField } from '@prismicio/types';
 type Item = {
 	name: string,
 	link: LinkField,
+	attributes?: string,
 };
 
 const response = await prismic.getSingle('social_channels');
@@ -30,11 +31,15 @@ const { channel } = response.data;
 
 
 const socialChannelList = channel.map((item: Item, index: number): string => {
-	const { name, link } = item;
+	const { name, link, attributes } = item;
 
 	return `
 		${index === channel.length - 1 ? 'and' : ''}
-		<a href="${prismicHelpers.asLink(link)}" target="_blank">${name}</a>
+		<a
+			href="${prismicHelpers.asLink(link)}"
+			target="_blank"
+			${attributes || ''}
+		>${name}</a>
 	`.trim();
 }).join(', ');
 ---


### PR DESCRIPTION
## Description
- Added 'attributes' field to channel items in the `MainFooter` component
- Added the same field on the Prismic side

## Tasks
- [Add Mastodon verification...](https://todoist.com/showTask?id=6481241918)