### PR TITLE
Bug/mobile type too small

### DIFF
--- a/src/scripts/SideNote.ts
+++ b/src/scripts/SideNote.ts
@@ -24,6 +24,7 @@ const style = `
 		}
 
 		.label {
+			--size: 2em;
 			background-color: var(--label-bg);
 			border: 0;
 			border-radius: 1000px;
@@ -32,10 +33,10 @@ const style = `
 			display: inline-block;
 			font-family: var(--type-font-accent);
 			font-size: 0.6em;
-			line-height: inherit;
+			line-height: var(--size);
 			margin-inline: 0.25em;
-			min-height: 2em;
-			min-width: 2em;
+			min-height: var(--size);
+			min-width: var(--size);
 			padding-block: 0;
 			padding-inline: 0.5rem;
 			position: relative;

--- a/src/scripts/SideNote.ts
+++ b/src/scripts/SideNote.ts
@@ -18,14 +18,15 @@ const style = `
 		}
 
 		.sidenote {
-			--label-color: var(--color-primary);
+			--label-color: var(--color-bg);
+			--label-bg: var(--color-primary);
 			display: inline;
 		}
 
 		.label {
-			background-color: transparent;
+			background-color: var(--label-bg);
+			border: 0;
 			border-radius: 1000px;
-			border: 2px solid var(--label-color);
 			color: var(--label-color);
 			cursor: pointer;
 			display: inline-block;
@@ -39,13 +40,13 @@ const style = `
 			padding-inline: 0.5rem;
 			position: relative;
 			text-align: center;
-			transition: color 0.25s ease, border-color 0.25s ease;
+			transition: background-color 0.25s ease;
 			vertical-align: top;
 		}
 
 		.label:hover,
 		.is-open .label {
-			--label-color: var(--color-highlight);
+			--label-bg: var(--color-highlight);
 		}
 
 		.content,
@@ -55,30 +56,32 @@ const style = `
 			top: auto;
 		}
 
-		.content {
+		.is-open .content {
+			display: block;
+			float: left;
+			left: auto;
+			min-width: 100%;
+			overflow: hidden;
+			padding-block: var(--space-narrow);
+			position: relative;
+			z-index: 4;
+		}
+
+		/* use an additional wrapper element inside .content so Safari doesn't mess up spacing - it collapses margins if we apply these styles to .content */
+		.wrapper {
 			align-items: flex-start;
-			border-radius: 0.2em;
 			display: flex;
 			font-family: var(--type-font-accent);
 			font-size: var(--type-scale-zeta);
 			gap: var(--space-xnarrow);
+			background-color: var(--color-well);
+			border-radius: 0.2em;
+			padding: var(--space-narrow);
 		}
 
-		.content::before {
+		.wrapper::before {
 			color: var(--color-highlight);
 			content: attr(data-count) ".";
-		}
-
-		.is-open .content {
-			background-color: var(--color-well);
-			float: left;
-			left: auto;
-			margin-block: var(--space-narrow);
-			min-width: 100%;
-			overflow: hidden;
-			padding: var(--space-narrow);
-			position: relative;
-			z-index: 4;
 		}
 
 		.text {
@@ -121,14 +124,15 @@ class SideNote extends HTMLElement {
 		this.#shadowRoot.innerHTML = `
 			${style}
 
-			<span class="sidenote" id="sidenote-${this.number}">
+			<span class="sidenote is-open" id="sidenote-${this.number}">
 				<button class="label" aria-label="Toggle the note">${this.number}</button>
 				<small
 					class="content"
-					data-count="${this.number}"
 					aria-role="note"
 				>
-					<span class="text"><slot></slot></span>
+					<span class="wrapper" data-count="${this.number}">
+						<span class="text"><slot></slot></span>
+					</span>
 				</small>
 			</span>
 		`;

--- a/src/scripts/SideNote.ts
+++ b/src/scripts/SideNote.ts
@@ -124,7 +124,7 @@ class SideNote extends HTMLElement {
 		this.#shadowRoot.innerHTML = `
 			${style}
 
-			<span class="sidenote is-open" id="sidenote-${this.number}">
+			<span class="sidenote" id="sidenote-${this.number}">
 				<button class="label" aria-label="Toggle the note">${this.number}</button>
 				<small
 					class="content"

--- a/src/styles/base/type.css
+++ b/src/styles/base/type.css
@@ -110,7 +110,6 @@ p {
 
 a {
 	--underline-w: 0.125em;
-	--underline-offset: 0.08em;
 
 	border-bottom: var(--underline-w) solid var(--color-highlight);
 	color: inherit;
@@ -125,7 +124,6 @@ a {
 		text-decoration-color: var(--color-highlight);
 		text-decoration-style: solid;
 		text-decoration-thickness: var(--underline-w);
-		text-underline-offset: var(--underline-offset);
 		text-underline-position: under;
 	}
 }

--- a/src/styles/tokens/type.css
+++ b/src/styles/tokens/type.css
@@ -8,7 +8,7 @@
 	--type-scale-beta: clamp(1.81rem, calc(1.26rem + 2.77vw), 3.75rem);
 	--type-scale-gamma: clamp(1.44rem, calc(1.12rem + 1.61vw), 2.56rem);
 	--type-scale-delta: clamp(1.13rem, calc(0.93rem + 0.98vw), 1.81rem);
-	--type-scale-epsilon: clamp(1rem, calc(0.86rem + 0.71vw), 1.5rem);
+	--type-scale-epsilon: clamp(1.13rem, calc(1.02rem + 0.54vw), 1.5rem);
 	--type-scale-zeta: clamp(0.88rem, calc(0.77rem + 0.54vw), 1.25rem);
 
 	/* --- fonts --- */


### PR DESCRIPTION
## Description
- Bumped up the size of `epsilon` type tokens on the smallest screen sizes (Iowan is optically smaller than Publico)
- Refined the layout of the SideNote components to address a bug/quirk in Safari with spacing