### PR TITLE
Various speed/accessibility fixes

### DIFF
--- a/src/components/Block.astro
+++ b/src/components/Block.astro
@@ -65,11 +65,11 @@ const classList = ['block', displayModeClass, className].join(' ');
 const style = `--block-width: var(--content-width-${getWidth(block.prominence)});`;
 ---
 
-<RevealOnScroll class={classList}>
+<div class={classList}>
 	<div class="wrapper" {style}>
 		<Component {...block} />
 	</div>
-</RevealOnScroll>
+</div>
 
 <style>
 	.block.flow {

--- a/src/components/Block.astro
+++ b/src/components/Block.astro
@@ -80,7 +80,7 @@ const style = `--block-width: var(--content-width-${getWidth(block.prominence)})
 		display: flex;
 		flex-direction: column;
 		min-height: 100vh;
-		padding-block: var(--space-wide);
+		padding-block: var(--space-xwide);
 		padding-inline: var(--space-outside);
 	}
 

--- a/src/components/blocks/Billboard.astro
+++ b/src/components/blocks/Billboard.astro
@@ -51,7 +51,7 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 
 <article>
 	<header>
-		<Heading level={1}>
+		<Heading level={2} class="type-scale-alpha">
 			<a
 				class="type-link-undecorated"
 				href={resolvedLink}

--- a/src/components/blocks/Billboard.astro
+++ b/src/components/blocks/Billboard.astro
@@ -117,11 +117,11 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 	}
 
 	article {
+		align-items: center;
 		display: grid;
 		flex: 1;
-		grid-template-rows: repeat(auto-fit, minmax(auto, 1fr));
 		gap: var(--space-medium);
-		align-items: center;
+		grid-template-rows: repeat(auto-fit, minmax(auto, 1fr));
 	}
 
 	article :global(.cover) {

--- a/src/components/blocks/Feed.astro
+++ b/src/components/blocks/Feed.astro
@@ -15,7 +15,6 @@ import Gallery from '@components/layout/Gallery.astro';
 import Heading from '@components/blocks/Heading.astro';
 import Passage from '@components/blocks/Passage.astro';
 import Button from '@components/elements/Button.astro';
-import Number from '@components/elements/Number.astro';
 import PostListing from '@components/navigation/BlogListingsPost.astro';
 
 // types
@@ -86,7 +85,7 @@ if (contentSource === 'blog_post') {
 
 <article>
 	<header>
-		<Heading level={1}>
+		<Heading level={2} class="type-scale-alpha">
 			<a
 				class="type-link-undecorated"
 				href={resolvedLink}

--- a/src/components/blocks/Figure.astro
+++ b/src/components/blocks/Figure.astro
@@ -7,6 +7,7 @@ import '@styles/tokens/contentWidth.css';
 import Image from '@components/elements/Image.astro';
 import DeviceFrame from '@components/elements/DeviceFrame.astro';
 import Caption from '@components/blocks/FigureCaption.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // typescript
 import type { ImageField } from '@prismicio/types';
@@ -38,7 +39,10 @@ const {
 } = Astro.props as Props;
 ---
 
-<figure class={className}>
+<RevealOnScroll
+	class={className}
+	tag="figure"
+>
 	<slot>
 		{source && (
 			device !== 'None'
@@ -61,7 +65,7 @@ const {
 			{attribution}
 		/>
 	)}
-</figure>
+</RevealOnScroll>
 
 <style>
 	figure {

--- a/src/components/blocks/ImageGallery.astro
+++ b/src/components/blocks/ImageGallery.astro
@@ -4,6 +4,7 @@ import DeviceFrame from '@components/elements/DeviceFrame.astro';
 import Image from '@components/elements/Image.astro';
 import Figure from '@components/blocks/Figure.astro';
 import Gallery from '@components/layout/Gallery.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
 import type { SpaceScale, FormattedText, ImageFit, Device } from '@lib/types';
@@ -47,7 +48,7 @@ const {
 		{gutter}
 	>
 		{images.map((image) => (
-			<li>
+			<RevealOnScroll tag="li">
 				{image?.device !== 'None'
 					? <DeviceFrame
 							type={image.device}
@@ -59,7 +60,7 @@ const {
 							{border}
 						/>
 				}
-			</li>
+			</RevealOnScroll>
 		))}
 	</Gallery>
 </Figure>

--- a/src/components/blocks/Pullquote.astro
+++ b/src/components/blocks/Pullquote.astro
@@ -13,6 +13,7 @@ import type { ImageField } from '@prismicio/types';
 
 // components
 import Passage from '@components/blocks/Passage.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 export interface Props {
 	text: FormattedText;
@@ -52,13 +53,15 @@ function variables(): string {
 }
 ---
 
-<aside
-	aria-role="presentation"
-	class={className}
-	style={variables()}
->
-	<Passage {text} typeSize="delta" class={image ? 'hide-visually' : ''} />
-</aside>
+<RevealOnScroll>
+	<aside
+		aria-role="presentation"
+		class={className}
+		style={variables()}
+	>
+		<Passage {text} typeSize="delta" class={image ? 'hide-visually' : ''} />
+	</aside>
+</RevealOnScroll>
 
 <style>
 	aside {

--- a/src/components/blocks/Pullquote.astro
+++ b/src/components/blocks/Pullquote.astro
@@ -55,7 +55,7 @@ function variables(): string {
 
 <RevealOnScroll>
 	<aside
-		aria-role="presentation"
+		role="presentation"
 		class={className}
 		style={variables()}
 	>

--- a/src/components/layout/BookCard.astro
+++ b/src/components/layout/BookCard.astro
@@ -42,10 +42,13 @@ const {
 ---
 
 <article class={className}>
-	<RevealOnScroll class="wrapper">
+	<div class="wrapper">
 
 		<!-- cover -->
-		<figure class="cover">
+		<RevealOnScroll
+			tag="figure"
+			class="cover"
+		>
 			<slot name="cover">
 				{cover
 					? <img
@@ -57,7 +60,7 @@ const {
 					: <div class="cover-image placeholder"></div>
 				}
 			</slot>
-		</figure>
+		</RevealOnScroll>
 
 		<!-- title, author, etc. -->
 		<header>
@@ -97,7 +100,7 @@ const {
 				))}
 			</footer>
 		)}
-	</RevealOnScroll>
+	</div>
 </article>
 
 <style>

--- a/src/components/layout/CardWithImage.astro
+++ b/src/components/layout/CardWithImage.astro
@@ -5,6 +5,7 @@ import '@styles/tokens/contentWidth.css';
 
 // components
 import Image from '@components/elements/Image.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
 import { ImageField } from '@prismicio/types';
@@ -22,10 +23,12 @@ const {
 
 <figure class={className}>
 	<div class="wrapper">
-		<Image
-			class="image"
-			source={image}
-		/>
+		<RevealOnScroll>
+			<Image
+				class="image"
+				source={image}
+			/>
+		</RevealOnScroll>
 		<figcaption>
 			<slot></slot>
 		</figcaption>

--- a/src/components/navigation/BlogListingsPost.astro
+++ b/src/components/navigation/BlogListingsPost.astro
@@ -33,7 +33,7 @@ const {
 } = Astro.props as Props;
 ---
 
-<RevealOnScroll tag="article">
+<article>
 	<Heading level={6} subheading class="eyebrow">
 		{showStage && <DevelopmentStageLabel name={stage} />}
 		<time datetime={date}>{format(date, 'yyyy.MM.dd')}</time>
@@ -52,7 +52,7 @@ const {
 			<a class="type-link-undecorated" href={path}>{subtitle}</a>
 		</Heading>
 	)}
-</RevealOnScroll>
+</article>
 
 <style>
 	.eyebrow {

--- a/src/components/navigation/MainFooter.astro
+++ b/src/components/navigation/MainFooter.astro
@@ -82,9 +82,10 @@ const socialChannelList = channel.map((item: Item, index: number): string => {
 
 <style>
 	footer {
-		position: relative;
-		padding-inline: var(--space-outside);
 		flex-shrink: 0;
+		margin-block-start: auto;
+		padding-inline: var(--space-outside);
+		position: relative;
 	}
 
 	.social {
@@ -99,7 +100,6 @@ const socialChannelList = channel.map((item: Item, index: number): string => {
 	.social > :global(a) {
 		color: var(--color-primary);
 		font-family: var(--type-font-accent);
-		/* font-weight: 600; */
 	}
 
 	.signoff {

--- a/src/components/navigation/MainFooter.astro
+++ b/src/components/navigation/MainFooter.astro
@@ -46,16 +46,10 @@ const socialChannelList = channel.map((item: Item, index: number): string => {
 ---
 
 <footer class="border-seam-top">
-	<RevealOnScroll
-		tag="p"
-		class="social | type-role-accent"
-	>
+	<p class="social | type-role-accent">
 		Keep in touch. You can also find me on <Fragment set:html={socialChannelList} />.
-	</RevealOnScroll>
-	<RevealOnScroll
-		tag="div"
-		class="signoff"
-	>
+	</p>
+	<div class="signoff">
 		<div class="bookend">
 			<div class="lockup">
 				<a
@@ -77,7 +71,7 @@ const socialChannelList = channel.map((item: Item, index: number): string => {
 				<Icon svg={feed} />
 			</a>
 		</div>
-	</RevealOnScroll>
+	</div>
 </footer>
 
 <style>

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -50,7 +50,7 @@ const {
 	<!-- nav -->
 	<jp-hamburger-nav>
 		<nav class="type-align-right" id="nav-wrapper">
-			<ul id="nav-list">
+			<ul class="is-hidden" id="nav-list">
 				{routes.map(({ label, link }) => (
 					<li>
 						<a
@@ -73,7 +73,6 @@ const {
 			super();
 
 			// DOM element references
-			this.wrapper = null;
 			this.button = null;
 			this.list = null;
 
@@ -82,10 +81,8 @@ const {
 		}
 
 		connectedCallback() {
-
 			// render JS-dependent buttons
-			this.wrapper = this.querySelector('#nav-wrapper');
-			this.wrapper.insertAdjacentHTML('afterbegin', this.renderButton(false));
+			this.renderButton(this.querySelector('#nav-wrapper'));
 
 			// select elements we need to work with
 			this.button = this.querySelector('#nav-button');
@@ -96,17 +93,10 @@ const {
 
 			// event listeners
 			this.button.addEventListener('click', () => {
-				console.log('toggle');
-
-				if (!this.open) {
-					this.open = true;
-				} else {
-					this.open = false;
-				}
+				this.open = !this.open;
 			});
 
 			this.list.addEventListener('transitionend', () => {
-				console.log('transition', this.open);
 				if (!this.open) this.hideNav();
 			});
 		}
@@ -131,8 +121,8 @@ const {
 			this.list.classList.add('is-hidden');
 		}
 
-		renderButton() {
-			return `
+		renderButton(container) {
+			const template = `
 				<button
 					aria-expanded="false"
 					class="nav-button | type-role-accent type-scale-epsilon"
@@ -145,6 +135,8 @@ const {
 					</svg>
 				</button>
 			`;
+
+			container.insertAdjacentHTML('afterbegin', template);
 		}
 	}
 
@@ -232,8 +224,8 @@ const {
   /* --- small-screen nav --- */
   :global([data-supports~='js']) #nav-list {
 		align-items: flex-start;
-    bottom: 0;
     background-color: hsl(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95);
+    bottom: 0;
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-narrow);
@@ -254,7 +246,7 @@ const {
   }
 
   /* closed (visually hidden) state */
-  :global([data-supports~='js']) #nav-list.is-hidden {
+  #nav-list.is-hidden {
     border: 0;
     clip-path: inset(100%);
     clip: rect(1px, 1px, 1px, 1px);
@@ -266,7 +258,7 @@ const {
   }
 
   /* open (transitioned) state */
-  :global([data-supports~='js']) #nav-list.is-open {
+  #nav-list.is-open {
     opacity: 1;
   }
 

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -222,7 +222,7 @@ const {
 	}
 
   /* --- small-screen nav --- */
-  :global([data-supports~='js']) #nav-list {
+  #nav-list {
 		align-items: flex-start;
     background-color: hsl(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95);
     bottom: 0;
@@ -267,8 +267,8 @@ const {
     margin-block-start: 0;
   }
 
+	/* prevent scrolling on the body when the overlay is displayed */
 	:global(.has-overlay) {
-		/* prevent scrolling on the body when the overlay is displayed */
 		height: 100vh;
 		height: 100dvh;
 		overflow: hidden;
@@ -301,19 +301,20 @@ const {
 
   /* --- large-screen nav --- */
   @media screen and (min-width: 43em) {
-    .nav-button {
+    jp-hamburger-nav :global(.nav-button) {
       display: none;
     }
 
-    .nav,
-    :global([data-supports~='js']) .nav {
+    #nav-list {
       background-color: transparent;
-      display: inline-block;
+      display: inline-flex;
+			flex-direction: row;
+			gap: var(--space-narrow);
       opacity: 1;
       position: relative;
     }
 
-    :global([data-supports~='js']) .nav.closed {
+    #nav-list.is-hidden {
       clip-path: none;
       clip: auto;
       height: auto;
@@ -348,17 +349,6 @@ const {
 
     .nav-item.small-only {
       display: none;
-    }
-
-    #nav-list > li {
-      display: inline-block;
-    }
-
-    #nav-list > li + li {
-      margin-inline-start: 1em;
-      margin-inline-start: var(--space-narrow);
-      margin-block-start:  0;
-      padding-block-start: 0;
     }
   }
 </style>

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -49,8 +49,8 @@ const {
 
 	<!-- nav -->
 	<jp-hamburger-nav>
-		<nav class="nav-wrapper type-align-right">
-			<ul class="nav-list" hidden>
+		<nav class="type-align-right" id="nav-wrapper">
+			<ul id="nav-list">
 				{routes.map(({ label, link }) => (
 					<li>
 						<a
@@ -73,89 +73,87 @@ const {
 			super();
 
 			// DOM element references
-			this.button = null;
 			this.wrapper = null;
+			this.button = null;
+			this.list = null;
 
 			// state
-			this.isOpen = false;
+			this._open = false;
 		}
 
 		connectedCallback() {
-			console.log('hello')
+
 			// render JS-dependent buttons
-			this.wrapper = this.querySelector('.nav-wrapper');
+			this.wrapper = this.querySelector('#nav-wrapper');
 			this.wrapper.insertAdjacentHTML('afterbegin', this.renderButton(false));
-			this.hideNav();
 
 			// select elements we need to work with
-			this.button = this.querySelector('#nav-button-open');
-			this.closeButton = this.querySelector('#nav-button-close');
+			this.button = this.querySelector('#nav-button');
+			this.list = this.querySelector('#nav-list');
+
+			// hide the nav initially
+			this.hideNav();
 
 			// event listeners
 			this.button.addEventListener('click', () => {
-				console.log('open')
-				this.open = true;
+				console.log('toggle');
+
+				if (!this.open) {
+					this.open = true;
+				} else {
+					this.open = false;
+				}
 			});
 
-			this.closeButton.addEventListener('click', () => {
-				this.open = false;
-			});
-
-			this.wrapper.addEventListener('ontransitionend', () => {
+			this.list.addEventListener('transitionend', () => {
+				console.log('transition', this.open);
 				if (!this.open) this.hideNav();
 			});
 		}
 
 		set open(state) {
-			this.isOpen = state;
-
-			if (state) this.openNav();
-			if (!state) this.closeNav();
+			this._open = state;
+			this.toggleNav();
 		}
 
 		get open() {
-			return this.open || false;
+			return this._open || false;
 		}
 
-		openNav() {
-			this.wrapper.setAttribute('hidden', 'false');
-			this.classList.add('open');
-			this.button.setAttribute('aria-expanded', 'true');
-		}
-
-		closeNav() {
-			this.classList.remove('open');
-			this.button.setAttribute('aria-expanded', 'false');
+		toggleNav() {
+			this.list.classList.toggle('is-open');
+			this.list.classList.remove('is-hidden');
+			this.button.setAttribute('aria-expanded', this.open.toString());
 		}
 
 		hideNav() {
-			this.wrapper.setAttribute('hidden', 'true');
+			this.list.classList.add('is-hidden');
 		}
 
-		renderButton(open = false) {
-			const openIcon = `
-				<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-					<path d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
-				</svg>
-			`;
-
-			const closeIcon = `
-				<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-					<path d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
-				</svg>
-			`;
-
+		renderButton() {
 			return `
 				<button
 					aria-expanded="false"
 					class="nav-button | type-role-accent type-scale-epsilon"
-					id="nav-button-open"
+					id="nav-button"
 				>
 					<span class="hide-visually">Menu</span>
-					${open ? openIcon : closeIcon}
+					<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+						<path d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
 					</svg>
 				</button>
 			`;
+		}
+
+		changeButtonMode() {
+			const closeIcon = `
+				<svg class="icon close" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+					<path d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
+				</svg>
+			`;
+
+			this.button.insertAdjacentHTML('beforeend', closeIcon);
+			const icon = this.button.querySelector('.icon');
 		}
 	}
 
@@ -194,6 +192,8 @@ const {
     padding: 0;
     transition: color 0.25s ease-in-out;
     will-change: color;
+		z-index: 5;
+		position: relative;
   }
 
   jp-hamburger-nav :global(.nav-button:hover),
@@ -222,16 +222,22 @@ const {
 	}
 
   /* --- small-screen nav --- */
-  :global([data-supports~='js']) .nav-wrapper {
-		align-items: center;
+  :global([data-supports~='js']) #nav-list {
+		align-items: flex-start;
+    bottom: 0;
+    background-color: hsl(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95);
 		display: flex;
 		flex-direction: column;
+		gap: var(--space-narrow);
 		justify-content: center;
-    background-color: hsl(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95);
-    bottom: 0;
-    display: block;
     left: 0;
+		list-style: none;
+		margin: 0;
     opacity: 0;
+		overflow-y: scroll;
+		padding-block: var(--space-wide);
+		padding-inline-start: 25%;
+		padding-inline-end: var(--space-outside);
     position: fixed;
     right: 0;
     top: 0;
@@ -240,7 +246,7 @@ const {
   }
 
   /* closed (visually hidden) state */
-  /* :global([data-supports~='js']) jp-hamburger-nav.closed {
+  :global([data-supports~='js']) #nav-list.is-hidden {
     border: 0;
     clip-path: inset(100%);
     clip: rect(1px, 1px, 1px, 1px);
@@ -249,30 +255,16 @@ const {
     padding: 0;
     position: absolute;
     width: 1px;
-  } */
+  }
 
   /* open (transitioned) state */
-  :global([data-supports~='js']) jp-hamburger-nav.open .nav-wrapper {
+  :global([data-supports~='js']) #nav-list.is-open {
     opacity: 1;
   }
 
-  .nav-list {
-    display: inline-block;
-    list-style: none;
-    margin: 0;
-  }
-
-  :global([data-supports~='js']) .nav-list {
-    display: block;
-  }
-
-  .nav-list > li {
+  #nav-list > li {
     display: block;
     margin-block-start: 0;
-  }
-
-  .nav-list > li + li {
-    padding-block-start: var(--space-narrow);
   }
 
   .nav-item {
@@ -350,11 +342,11 @@ const {
       display: none;
     }
 
-    .nav-list > li {
+    #nav-list > li {
       display: inline-block;
     }
 
-    .nav-list > li + li {
+    #nav-list > li + li {
       margin-inline-start: 1em;
       margin-inline-start: var(--space-narrow);
       margin-block-start:  0;

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -87,27 +87,10 @@ const {
 			// only run this script if the screen is small enough to need a hamburger menu
 			const breakpoint = window.matchMedia(this._breakpoint);
 
+			if (breakpoint.matches) this.render();
+
 			breakpoint.addEventListener('change', () => {
-				if (breakpoint.matches) {
-					// render JS-dependent buttons
-					this.renderButton(this.querySelector('#nav-wrapper'));
-
-					// select elements we need to work with
-					this.button = this.querySelector('#nav-button');
-					this.list = this.querySelector('#nav-list');
-
-					// hide the nav initially
-					this.hideNav();
-
-					// event listeners
-					this.button.addEventListener('click', () => {
-						this.open = !this.open;
-					});
-
-					this.list.addEventListener('transitionend', () => {
-						if (!this.open) this.hideNav();
-					});
-				}
+				if (breakpoint.matches) this.render();
 			});
 		}
 
@@ -138,7 +121,7 @@ const {
 					class="nav-button | type-role-accent type-scale-epsilon"
 					id="nav-button"
 				>
-					<span class="hide-visually">Menu</span>
+					<span>Menu</span>
 					<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 						<path class="open" d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
 						<path class="close" d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
@@ -147,6 +130,29 @@ const {
 			`;
 
 			container.insertAdjacentHTML('afterbegin', template);
+		}
+
+		render() {
+			// render JS-dependent buttons
+			if (!this.button) {
+				this.renderButton(this.querySelector('#nav-wrapper'));
+
+				// select elements we need to work with
+				this.button = this.querySelector('#nav-button');
+				this.list = this.querySelector('#nav-list');
+
+				// hide the nav initially
+				this.hideNav();
+
+				// event listeners
+				this.button.addEventListener('click', () => {
+					this.open = !this.open;
+				});
+
+				this.list.addEventListener('transitionend', () => {
+					if (!this.open) this.hideNav();
+				});
+			}
 		}
 	}
 
@@ -233,7 +239,7 @@ const {
 
   /* --- small-screen nav --- */
   #nav-list {
-		align-items: flex-start;
+		align-items: center;
     background-color: hsl(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95);
     bottom: 0;
 		display: flex;
@@ -246,8 +252,8 @@ const {
     opacity: 0;
 		overflow-y: scroll;
 		padding-block: var(--space-wide);
-		padding-inline-start: 25%;
-		padding-inline-end: var(--space-outside);
+		/* padding-inline-start: 25%; */
+		padding-inline: var(--space-outside);
     position: fixed;
     right: 0;
     top: 0;
@@ -295,18 +301,23 @@ const {
 		font-weight: 300;
   }
 
+  .nav-item[aria-current="page"] {
+		--dot-size: 0.5em;
+		--dot-margin: 0.4em;
+
+		margin-inline-start: calc((var(--dot-margin) + var(--dot-size)) * -1);
+		display: flex;
+		gap: var(--dot-margin);
+		align-items: center;
+	}
+
   .nav-item[aria-current="page"]::before {
-    --size: 0.5em;
     background-color: var(--color-highlight);
     border-radius: 1000px;
     content: '';
     display: block;
-    height: var(--size);
-    left: calc(var(--space-medium) * -1);
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    width: var(--size);
+    height: var(--dot-size);
+    width: var(--dot-size);
   }
 
   /* --- large-screen nav --- */
@@ -316,10 +327,11 @@ const {
     }
 
     #nav-list {
-      background-color: transparent;
-      display: inline-flex;
+			align-items: flex-start;
 			flex-direction: row;
 			gap: var(--space-narrow);
+      background-color: transparent;
+      display: inline-flex;
       opacity: 1;
       position: relative;
     }
@@ -341,20 +353,24 @@ const {
 
     .nav-item:hover,
     .nav-item:active {
-      color: var(--color-highlight);
+			color: var(--color-highlight);
     }
 
+		.nav-item[aria-current="page"] {
+			display: block;
+			margin-inline-start: 0;
+		}
+
     .nav-item[aria-current="page"]::before {
-      background-color: var(--color-highlight);
-      height: 0.18em;
-      left: 0;
-      position: absolute;
-      right: 0;
-      bottom: -0.1em;
-			top: auto;
-      transform: none;
-      width: auto;
+			background-color: var(--color-highlight);
 			border-radius: 0;
+			bottom: -0.1em;
+			height: 0.18em;
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: auto;
+			width: auto;
     }
 
     .nav-item.small-only {

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -121,9 +121,10 @@ const {
 		}
 
 		toggleNav() {
+			this.button.setAttribute('aria-expanded', this.open.toString());
 			this.list.classList.toggle('is-open');
 			this.list.classList.remove('is-hidden');
-			this.button.setAttribute('aria-expanded', this.open.toString());
+			document.body.classList.toggle('has-overlay');
 		}
 
 		hideNav() {
@@ -139,21 +140,11 @@ const {
 				>
 					<span class="hide-visually">Menu</span>
 					<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-						<path d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
+						<path class="open" d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
+						<path class="close" d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
 					</svg>
 				</button>
 			`;
-		}
-
-		changeButtonMode() {
-			const closeIcon = `
-				<svg class="icon close" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-					<path d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
-				</svg>
-			`;
-
-			this.button.insertAdjacentHTML('beforeend', closeIcon);
-			const icon = this.button.querySelector('.icon');
 		}
 	}
 
@@ -221,6 +212,23 @@ const {
     width: 1em;
 	}
 
+	jp-hamburger-nav :global(.icon .open),
+	jp-hamburger-nav :global(.icon .close), {
+		transition: 0.25s opacity ease;
+	}
+
+	jp-hamburger-nav :global([aria-expanded='false'] .close) {
+		opacity: 0;
+	}
+
+	jp-hamburger-nav :global([aria-expanded='true'] .close) {
+		opacity: 1;
+	}
+
+	jp-hamburger-nav :global([aria-expanded='true'] .open) {
+		opacity: 0;
+	}
+
   /* --- small-screen nav --- */
   :global([data-supports~='js']) #nav-list {
 		align-items: flex-start;
@@ -267,6 +275,14 @@ const {
     margin-block-start: 0;
   }
 
+	:global(.has-overlay) {
+		/* prevent scrolling on the body when the overlay is displayed */
+		height: 100vh;
+		height: 100dvh;
+		overflow: hidden;
+	}
+
+	/* nav link elements */
   .nav-item {
     display: inline-block;
     font-size: var(--type-scale-delta);

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -81,23 +81,29 @@ const {
 		}
 
 		connectedCallback() {
-			// render JS-dependent buttons
-			this.renderButton(this.querySelector('#nav-wrapper'));
+			// only run this script if the screen is small enough to need a hamburger menu
+			const breakpoint = window.matchMedia('(max-width: 43em)');
+			breakpoint.addEventListener('change', () => {
+				if (breakpoint.matches) {
+					// render JS-dependent buttons
+					this.renderButton(this.querySelector('#nav-wrapper'));
 
-			// select elements we need to work with
-			this.button = this.querySelector('#nav-button');
-			this.list = this.querySelector('#nav-list');
+					// select elements we need to work with
+					this.button = this.querySelector('#nav-button');
+					this.list = this.querySelector('#nav-list');
 
-			// hide the nav initially
-			this.hideNav();
+					// hide the nav initially
+					this.hideNav();
 
-			// event listeners
-			this.button.addEventListener('click', () => {
-				this.open = !this.open;
-			});
+					// event listeners
+					this.button.addEventListener('click', () => {
+						this.open = !this.open;
+					});
 
-			this.list.addEventListener('transitionend', () => {
-				if (!this.open) this.hideNav();
+					this.list.addEventListener('transitionend', () => {
+						if (!this.open) this.hideNav();
+					});
+				}
 			});
 		}
 

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -5,8 +5,6 @@ import '@styles/tokens/spacing.css';
 import '@styles/tokens/type.css';
 import '@styles/utilities/type.css';
 import '@styles/utilities/visibility.css';
-import menu from '@icons/menu.svg?raw';
-import close from '@icons/close.svg?raw';
 
 // utils
 import prismic from '@lib/prismic';
@@ -14,14 +12,12 @@ import * as prismicHelpers from '@prismicio/helpers';
 import { linkResolver, fetchLinks } from '@lib/routes';
 
 // components
-import Icon from '@components/elements/Icon.astro';
 import LogoJP from '@components/logos/LogoJP.astro';
 
 // types
 export interface Props {
 	segment: string;
 	class?: string;
-	overlay?: boolean;
 }
 
 type mainNavLink = {
@@ -40,52 +36,10 @@ const routes = response.data.nav_item.map(
 const {
 	segment,
 	class:className = '',
-	overlay = false,
 } = Astro.props as Props;
-
-const classList = [
-	overlay ? 'overlay' : '',
-	className,
-].join(' ');
 ---
 
-<script>
-  // namespace for this component's JS
-  let MainNav = {
-		// current state
-		open: false,
-		$navButtonOpen: null,
-		$navButtonClose: null,
-		$navWrapper: null,
-	};
-
-	document.addEventListener('DOMContentLoaded', () => {
-		MainNav.$navButtonOpen = document.getElementById('nav-button-open');
-		MainNav.$navButtonClose = document.getElementById('nav-button-close');
-		MainNav.$navWrapper = document.getElementById('nav-wrapper');
-
-		MainNav.$navButtonOpen.onpointerdown = () => {
-			MainNav.open = true;
-			MainNav.$navWrapper.classList.remove('closed');
-			MainNav.$navWrapper.classList.add('open');
-			MainNav.$navButtonOpen.classList.add('hide');
-		}
-
-		MainNav.$navButtonClose.onpointerdown = () => {
-			MainNav.open = false;
-			MainNav.$navWrapper.classList.remove('open');
-			MainNav.$navButtonOpen.classList.remove('hide');
-		}
-
-		MainNav.$navWrapper.ontransitionend = () => {
-			if (!MainNav.open) {
-				MainNav.$navWrapper.classList.add('closed');
-			}
-		};
-	});
-</script>
-
-<nav class={classList}>
+<header class={className}>
 	<a
 		class="logo"
 		href="/"
@@ -94,32 +48,9 @@ const classList = [
 	</a>
 
 	<!-- nav -->
-	<div class="type-align-right">
-		<button
-			class="nav-button | type-role-accent type-scale-epsilon"
-			id="nav-button-open"
-		>
-			Menu
-			<Icon
-				svg={menu}
-				margin="left"
-			/>
-		</button>
-		<div
-			class="nav closed"
-			id="nav-wrapper"
-		>
-			<button
-				class="nav-button close type-scale-epsilon type-role-accent"
-				id="nav-button-close"
-			>
-				<Icon
-					svg={close}
-					margin="right"
-				/>
-				<span class="hide-visually">Close</span>
-			</button>
-			<ul class="nav-list">
+	<jp-hamburger-nav>
+		<nav class="nav-wrapper type-align-right">
+			<ul class="nav-list" hidden>
 				{routes.map(({ label, link }) => (
 					<li>
 						<a
@@ -132,28 +63,116 @@ const classList = [
 					</li>
 				))}
 			</ul>
-		</div>
-	</div>
-</nav>
+		</nav>
+	</jp-hamburger-nav>
+</header>
+
+<script is:inline type="module">
+	class HamburgerNav extends HTMLElement {
+		constructor() {
+			super();
+
+			// DOM element references
+			this.button = null;
+			this.wrapper = null;
+
+			// state
+			this.isOpen = false;
+		}
+
+		connectedCallback() {
+			console.log('hello')
+			// render JS-dependent buttons
+			this.wrapper = this.querySelector('.nav-wrapper');
+			this.wrapper.insertAdjacentHTML('afterbegin', this.renderButton(false));
+			this.hideNav();
+
+			// select elements we need to work with
+			this.button = this.querySelector('#nav-button-open');
+			this.closeButton = this.querySelector('#nav-button-close');
+
+			// event listeners
+			this.button.addEventListener('click', () => {
+				console.log('open')
+				this.open = true;
+			});
+
+			this.closeButton.addEventListener('click', () => {
+				this.open = false;
+			});
+
+			this.wrapper.addEventListener('ontransitionend', () => {
+				if (!this.open) this.hideNav();
+			});
+		}
+
+		set open(state) {
+			this.isOpen = state;
+
+			if (state) this.openNav();
+			if (!state) this.closeNav();
+		}
+
+		get open() {
+			return this.open || false;
+		}
+
+		openNav() {
+			this.wrapper.setAttribute('hidden', 'false');
+			this.classList.add('open');
+			this.button.setAttribute('aria-expanded', 'true');
+		}
+
+		closeNav() {
+			this.classList.remove('open');
+			this.button.setAttribute('aria-expanded', 'false');
+		}
+
+		hideNav() {
+			this.wrapper.setAttribute('hidden', 'true');
+		}
+
+		renderButton(open = false) {
+			const openIcon = `
+				<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+					<path d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
+				</svg>
+			`;
+
+			const closeIcon = `
+				<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+					<path d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
+				</svg>
+			`;
+
+			return `
+				<button
+					aria-expanded="false"
+					class="nav-button | type-role-accent type-scale-epsilon"
+					id="nav-button-open"
+				>
+					<span class="hide-visually">Menu</span>
+					${open ? openIcon : closeIcon}
+					</svg>
+				</button>
+			`;
+		}
+	}
+
+	export default customElements.define('jp-hamburger-nav', HamburgerNav);
+</script>
 
 <style>
 	/* --- layout --- */
-	nav {
+	header {
 		--transition: 0.25s;
 
 		padding-inline: var(--space-outside);
 		display: flex;
+		flex-direction: row;
+		align-items: center;
 		justify-content: space-between;
 	}
-
-	.overlay {
-		background-color: transparent;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 4;
-  }
 
   /* --- nav elements --- */
   .logo {
@@ -162,26 +181,27 @@ const classList = [
     max-width: 2.5rem;
   }
 
-  .nav-button {
+  jp-hamburger-nav :global(.nav-button) {
     background-color: transparent;
     border: 0;
     box-shadow: none;
     cursor: pointer;
-    display: inline-block;
-    margin-block-start: 1em;
-    margin-block-start: var(--space-narrow);
+    display: inline-flex;
+		flex-direction: row;
+		gap: 0.5em;
+		align-items: center;
     outline: none;
     padding: 0;
     transition: color 0.25s ease-in-out;
     will-change: color;
   }
 
-  .nav-button:hover,
-  .nav-button:active {
+  jp-hamburger-nav :global(.nav-button:hover),
+  jp-hamburger-nav :global(.nav-button:active) {
     color: var(--color-highlight);
   }
 
-  .nav-button.close {
+  jp-hamburger-nav :global(.nav-button.close) {
     margin-inline-end: 1.5em;
     margin-inline-end: var(--space-medium);
     position: absolute;
@@ -189,8 +209,24 @@ const classList = [
     top: 0;
   }
 
+	jp-hamburger-nav :global(.icon) {
+		color: currentColor;
+    display: inline-block;
+    fill: currentColor;
+    height: 1em;
+    max-height: 100%;
+    max-width: 100%;
+    pointer-events: none;
+    vertical-align: middle;
+    width: 1em;
+	}
+
   /* --- small-screen nav --- */
-  :global([data-supports~='js']) .nav {
+  :global([data-supports~='js']) .nav-wrapper {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
     background-color: hsl(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95);
     bottom: 0;
     display: block;
@@ -200,21 +236,11 @@ const classList = [
     right: 0;
     top: 0;
     transition: opacity 0.25s ease;
-    will-change: opacity;
     z-index: 4;
   }
 
-  @supports (display: flex) {
-    :global([data-supports~='js']) .nav {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-    }
-  }
-
   /* closed (visually hidden) state */
-  :global([data-supports~='js']) .nav.closed {
+  /* :global([data-supports~='js']) jp-hamburger-nav.closed {
     border: 0;
     clip-path: inset(100%);
     clip: rect(1px, 1px, 1px, 1px);
@@ -223,10 +249,10 @@ const classList = [
     padding: 0;
     position: absolute;
     width: 1px;
-  }
+  } */
 
   /* open (transitioned) state */
-  :global([data-supports~='js']) .nav.open {
+  :global([data-supports~='js']) jp-hamburger-nav.open .nav-wrapper {
     opacity: 1;
   }
 

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -78,11 +78,15 @@ const {
 
 			// state
 			this._open = false;
+
+			// config
+			this._breakpoint = '(max-width: 43em)';
 		}
 
 		connectedCallback() {
 			// only run this script if the screen is small enough to need a hamburger menu
-			const breakpoint = window.matchMedia('(max-width: 43em)');
+			const breakpoint = window.matchMedia(this._breakpoint);
+
 			breakpoint.addEventListener('change', () => {
 				if (breakpoint.matches) {
 					// render JS-dependent buttons

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -117,10 +117,8 @@ const themeTokens: ThemeTokens = theme
 		background-color: var(--color-bg);
 		color: var(--color-primary);
 		position: relative;
-		display: grid;
-		grid-template-rows: auto 1fr auto;
-		/* if pages using this layout have a different root structure, use the grid area names to put things in the right pace */
-		grid-template-areas: 'header' 'body' 'footer';
+		display: flex;
+		flex-direction: column;
 
 		/*
 		 * several versions of 'full height of window' depending on context/support

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,10 +5,6 @@ import '@styles/base/type.css';
 import '@styles/tokens/borders.css';
 import '@styles/tokens/color.css';
 
-// components
-import MainFooter from '@components/navigation/MainFooter.astro';
-import MainNav from '@components/navigation/MainNav.astro';
-
 // types
 import type {
 	ColorRoles,
@@ -108,18 +104,12 @@ const themeTokens: ThemeTokens = theme
 	</head>
 
 	<body>
-		<MainNav segment={path} overlay={overlayNav} />
-		<main>
-			<slot />
-		</main>
-		<MainFooter class="footer" />
+		<slot />
 	</body>
 </html>
 
 <!-- set the page theme as root custom properties to override the default tokens -->
-<style define:vars={themeTokens} is:global></style>
-
-<style>
+<style define:vars={themeTokens} is:global>
 	html {
 		/* make anchor links scroll smoothly */
 		scroll-behavior: smooth;
@@ -128,9 +118,11 @@ const themeTokens: ThemeTokens = theme
 	body {
 		background-color: var(--color-bg);
 		color: var(--color-primary);
+		position: relative;
 		display: grid;
 		grid-template-rows: auto 1fr auto;
-		position: relative;
+		/* if pages using this layout have a different root structure, use the grid area names to put things in the right pace */
+		grid-template-areas: 'header' 'body' 'footer';
 
 		/*
 		 * several versions of 'full height of window' depending on context/support

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -30,9 +30,7 @@ export type ThemeTokens = Partial<Record<`color-${ColorRoles}`, HexColor | HSLCo
 // props and data
 const {
 	pageTitle,
-	path = 'home',
 	seo = {},
-	overlayNav = false,
 	theme,
 } = Astro.props as Props;
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,8 +10,10 @@ import { fetchLinks } from '@lib/routes';
 // components
 import Layout from '@layouts/BaseLayout.astro';
 import BlockList from '@components/BlockList.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 import Heading from '@components/blocks/Heading.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
+import MainNav from '@components/navigation/MainNav.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
 
 const response = await prismic.getByUID('page', 'about', { fetchLinks });
 
@@ -33,19 +35,22 @@ const seo = {
 
 <Layout
 	pageTitle="about"
-	path="about"
 	{seo}
 >
-	<article>
-		<RevealOnScroll>
-			<Heading
-				level={1}
-				class="title"
-				text={title}
-			/>
-		</RevealOnScroll>
-		<BlockList {body} showLedeStyle />
-	</article>
+	<MainNav segment="about" />
+	<main>
+		<article>
+			<RevealOnScroll>
+				<Heading
+					level={1}
+					class="title"
+					text={title}
+				/>
+			</RevealOnScroll>
+			<BlockList {body} showLedeStyle />
+		</article>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -40,13 +40,11 @@ const seo = {
 	<MainNav segment="about" />
 	<main>
 		<article>
-			<RevealOnScroll>
-				<Heading
-					level={1}
-					class="title"
-					text={title}
-				/>
-			</RevealOnScroll>
+			<Heading
+				level={1}
+				class="title"
+				text={title}
+			/>
 			<BlockList {body} showLedeStyle />
 		</article>
 	</main>

--- a/src/pages/blog/[year]/[month]/[day]/[uid].astro
+++ b/src/pages/blog/[year]/[month]/[day]/[uid].astro
@@ -22,6 +22,8 @@ import Layout from '@layouts/BaseLayout.astro';
 import BlockList from '@components/BlockList.astro';
 import Button from '@components/elements/Button.astro';
 import Heading from '@components/blocks/Heading.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
 import ReadNextLink from '@components/navigation/ReadNextLink.astro';
 import ThreadNav from '@components/navigation/ThreadNav.astro';
 import ThreadNavItem from '@components/navigation/ThreadNavItem.astro';
@@ -157,102 +159,102 @@ const {
 } = Astro.props as Props;
 ---
 
-<Layout
-	pageTitle={prismicHelpers.asText(title)}
-	path="blog"
-	{seo}
->
-	<article>
-		<RevealOnScroll tag="header">
-			{prismicHelpers.isFilled.title(title) && (
-				<Heading level={1} class="title">{prismicHelpers.asText(title)}</Heading>
-			)}
-			{prismicHelpers.isFilled.title(subtitle) && (
-				<Heading subheading>{prismicHelpers.asText(subtitle)} </Heading>
-			)}
+<Layout pageTitle={prismicHelpers.asText(title)} {seo}>
+	<MainNav segment="blog" />
+	<main>
+		<article>
+			<RevealOnScroll tag="header" class="headline">
+				{prismicHelpers.isFilled.title(title) && (
+					<Heading level={1} class="title">{prismicHelpers.asText(title)}</Heading>
+				)}
+				{prismicHelpers.isFilled.title(subtitle) && (
+					<Heading subheading>{prismicHelpers.asText(subtitle)} </Heading>
+				)}
 
-			<!-- date and stage info -->
-			<PostMetadata
-				class="metadata | content-width"
-				showUpdatedDate
-				{date}
-				{stage}
-			/>
+				<!-- date and stage info -->
+				<PostMetadata
+					class="metadata | content-width"
+					showUpdatedDate
+					{date}
+					{stage}
+				/>
 
-			<!-- list of posts in a thread, if applicable -->
-			{thread && (
-				<ThreadNav
-					title={thread.title && prismicHelpers.asText(thread.title)}
-					description={thread.description &&prismicHelpers.asText(thread.description)}
-					class="thread-nav | content-width"
-				>
-					{thread.posts.map((post) => (
-						<ThreadNavItem
-							current={post.uid === uid}
-							date={post.data.date}
-							href={permalink(post)}
-							label={prismicHelpers.asText(post.data.title)}
-						/>
-					))}
-				</ThreadNav>
-			)}
-		</RevealOnScroll>
-
-		<!-- page body -->
-		<BlockList {body} showLedeStyle />
-
-		{link && (
-			<RevealOnScroll
-				tag="footer"
-				class="link"
-			>
-				<Button
-					href={link}
-					iconRight={externalLink}
-					target="_blank"
-				>
-					Direct link
-				</Button>
-			</RevealOnScroll>
-		)}
-	</article>
-
-	<!-- pagination nav -->
-	{(next || tags.length > 0) && (
-		<nav>
-			{tags.length > 0 && (
-				<RevealOnScroll
-					tag="section"
-					class="nav-wrapper tags"
-				>
-					<h2 class="tag-label type-role-accent type-scale-epsilon">Filed&nbsp;under:</h2>
-					<ul class="tag-list type-role-accent">
-						{tags.map((tag) => (
-							<li>
-								<a href={`/blog/tags/${tag}/`}>{sentenceCase(tag)}</a>
-							</li>
+				<!-- list of posts in a thread, if applicable -->
+				{thread && (
+					<ThreadNav
+						title={thread.title && prismicHelpers.asText(thread.title)}
+						description={thread.description &&prismicHelpers.asText(thread.description)}
+						class="thread-nav | content-width"
+					>
+						{thread.posts.map((post) => (
+							<ThreadNavItem
+								current={post.uid === uid}
+								date={post.data.date}
+								href={permalink(post)}
+								label={prismicHelpers.asText(post.data.title)}
+							/>
 						))}
-					</ul>
-				</RevealOnScroll>
-			)}
-			{next && (
+					</ThreadNav>
+				)}
+			</RevealOnScroll>
+
+			<!-- page body -->
+			<BlockList {body} showLedeStyle />
+
+			{link && (
 				<RevealOnScroll
-					tag="section"
-					class="nav-wrapper"
+					tag="footer"
+					class="link"
 				>
-					{next.title
-						? <ReadNextLink link={next.path}>
-								<Fragment slot="eyebrow">Next post:</Fragment>
-								<Fragment slot="title">{next.title}</Fragment>
-							</ReadNextLink>
-						: <ReadNextLink link={next.path}>
-								<Fragment slot="title">Next post</Fragment>
-							</ReadNextLink>
-					}
+					<Button
+						href={link}
+						iconRight={externalLink}
+						target="_blank"
+					>
+						Direct link
+					</Button>
 				</RevealOnScroll>
 			)}
-		</nav>
-	)}
+		</article>
+
+		<!-- pagination nav -->
+		{(next || tags.length > 0) && (
+			<nav>
+				{tags.length > 0 && (
+					<RevealOnScroll
+						tag="section"
+						class="nav-wrapper tags"
+					>
+						<h2 class="tag-label type-role-accent type-scale-epsilon">Filed&nbsp;under:</h2>
+						<ul class="tag-list type-role-accent">
+							{tags.map((tag) => (
+								<li>
+									<a href={`/blog/tags/${tag}/`}>{sentenceCase(tag)}</a>
+								</li>
+							))}
+						</ul>
+					</RevealOnScroll>
+				)}
+				{next && (
+					<RevealOnScroll
+						tag="section"
+						class="nav-wrapper"
+					>
+						{next.title
+							? <ReadNextLink link={next.path}>
+									<Fragment slot="eyebrow">Next post:</Fragment>
+									<Fragment slot="title">{next.title}</Fragment>
+								</ReadNextLink>
+							: <ReadNextLink link={next.path}>
+									<Fragment slot="title">Next post</Fragment>
+								</ReadNextLink>
+						}
+					</RevealOnScroll>
+				)}
+			</nav>
+		)}
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>
@@ -260,7 +262,7 @@ const {
 		padding-block: var(--space-xwide);
 	}
 
-	header {
+	.headline {
 		margin-inline: auto;
 		max-width: var(--content-width-xwide);
 		padding-block-end: var(--space-wide);

--- a/src/pages/blog/[year]/[month]/[day]/[uid].astro
+++ b/src/pages/blog/[year]/[month]/[day]/[uid].astro
@@ -163,7 +163,7 @@ const {
 	<MainNav segment="blog" />
 	<main>
 		<article>
-			<RevealOnScroll tag="header" class="headline">
+			<header class="headline">
 				{prismicHelpers.isFilled.title(title) && (
 					<Heading level={1} class="title">{prismicHelpers.asText(title)}</Heading>
 				)}
@@ -196,16 +196,13 @@ const {
 						))}
 					</ThreadNav>
 				)}
-			</RevealOnScroll>
+			</header>
 
 			<!-- page body -->
 			<BlockList {body} showLedeStyle />
 
 			{link && (
-				<RevealOnScroll
-					tag="footer"
-					class="link"
-				>
+				<footer class="link">
 					<Button
 						href={link}
 						iconRight={externalLink}
@@ -213,7 +210,7 @@ const {
 					>
 						Direct link
 					</Button>
-				</RevealOnScroll>
+				</footer>
 			)}
 		</article>
 

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -16,13 +16,15 @@ import * as prismicHelpers from '@prismicio/helpers';
 import prismic from '@lib/prismic';
 
 // components
-import BlockList from '@components/BlockList.astro';
-import Button from '@components/elements/Button.astro';
-import Heading from '@components/blocks/Heading.astro';
-import Icon from '@components/elements/Icon.astro';
 import Layout from '@layouts/BaseLayout.astro';
+import Button from '@components/elements/Button.astro';
+import Icon from '@components/elements/Icon.astro';
 import PostMetadata from '@components/elements/PostMetadata.astro';
+import Heading from '@components/blocks/Heading.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
+import MainNav from '@components/navigation/MainNav.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import BlockList from '@components/BlockList.astro';
 
 export async function getStaticPaths({ paginate }): Promise<Function> {
 	const posts = await prismic.getAllByType('blog_post', {
@@ -74,94 +76,94 @@ const postList = page.data.map(({
 });
 ---
 
-<Layout
-	path="blog"
-	pageTitle="Blog"
->
-	<ul class="post-list" aria-role="feed">
-		{postList.map((post, index) => (
-			<li class={index > 0 ? 'border-seam-top' : ''}>
-				<article
-					class="post"
-					id={post.uid}
-				>
-					<RevealOnScroll
-						tag="header"
-						class="post-header"
+<Layout pageTitle="Blog">
+	<MainNav segment="blog" />
+	<main>
+		<ul class="post-list" aria-role="feed">
+			{postList.map((post, index) => (
+				<li class={index > 0 ? 'border-seam-top' : ''}>
+					<article
+						class="post"
+						id={post.uid}
 					>
-						{prismicHelpers.isFilled.title(post.title) && (
-							<Heading level={2} class="post-title">
-								<a
-									href={post.path}
-									class="type-link-undecorated"
-									>
-									{prismicHelpers.asText(post.title)}
-								</a>
-							</Heading>
-						)}
-						{prismicHelpers.isFilled.title(post.subtitle) && (
-							<Heading subheading level={3}>{prismicHelpers.asText(post.subtitle)}</Heading>
-						)}
-						<PostMetadata {...post} class="post-date | content-width" />
-					</RevealOnScroll>
-					<BlockList body={post.summary} showLedeStyle />
-					{(post.readMore || post.link) && (
-						<footer class="post-footer">
-							<div class="post-buttons | wrapper">
-								{post.readMore && (
-									<Button
+						<RevealOnScroll
+							tag="header"
+							class="post-header"
+						>
+							{prismicHelpers.isFilled.title(post.title) && (
+								<Heading level={2} class="post-title">
+									<a
 										href={post.path}
-										iconRight={arrowRight}
-									>
-										Read more
-									</Button>
-								)}
-								{post.link && (
-									<Button
-										href={post.link}
-										iconRight={externalLink}
-										target="_blank"
-									>
-										Direct link
-									</Button>
-								)}
-							</div>
-						</footer>
-					)}
-				</article>
-			</li>
-		))}
-	</ul>
-
-	<nav class="border-seam-top">
-		<RevealOnScroll
-			tag="ul"
-			class="nav-list"
-		>
-			{prev && (
-				<li class="nav-item">
-					<a
-						class="nav-link | type-scale-delta"
-						href={prev}
-					>
-						<Icon svg={arrowLeft} class="nav-icon before" />
-						<span class="nav-label | type-role-accent">Newer posts</span>
-					</a>
+										class="type-link-undecorated"
+										>
+										{prismicHelpers.asText(post.title)}
+									</a>
+								</Heading>
+							)}
+							{prismicHelpers.isFilled.title(post.subtitle) && (
+								<Heading subheading level={3}>{prismicHelpers.asText(post.subtitle)}</Heading>
+							)}
+							<PostMetadata {...post} class="post-date | content-width" />
+						</RevealOnScroll>
+						<BlockList body={post.summary} showLedeStyle />
+						{(post.readMore || post.link) && (
+							<footer class="post-footer">
+								<div class="post-buttons | wrapper">
+									{post.readMore && (
+										<Button
+											href={post.path}
+											iconRight={arrowRight}
+										>
+											Read more
+										</Button>
+									)}
+									{post.link && (
+										<Button
+											href={post.link}
+											iconRight={externalLink}
+											target="_blank"
+										>
+											Direct link
+										</Button>
+									)}
+								</div>
+							</footer>
+						)}
+					</article>
 				</li>
-			)}
-			{next && (
-				<li class="nav-item">
-					<a
-						class="nav-link | type-scale-delta"
-						href={next}
-					>
-						<span class="nav-label | type-role-accent">Older posts</span>
-						<Icon svg={arrowRight} class="nav-icon after" />
-					</a>
-				</li>
-			)}
-		</RevealOnScroll>
-	</nav>
+			))}
+		</ul>
+		<nav class="border-seam-top">
+			<RevealOnScroll
+				tag="ul"
+				class="nav-list"
+			>
+				{prev && (
+					<li class="nav-item">
+						<a
+							class="nav-link | type-scale-delta"
+							href={prev}
+						>
+							<Icon svg={arrowLeft} class="nav-icon before" />
+							<span class="nav-label | type-role-accent">Newer posts</span>
+						</a>
+					</li>
+				)}
+				{next && (
+					<li class="nav-item">
+						<a
+							class="nav-link | type-scale-delta"
+							href={next}
+						>
+							<span class="nav-label | type-role-accent">Older posts</span>
+							<Icon svg={arrowRight} class="nav-icon after" />
+						</a>
+					</li>
+				)}
+			</RevealOnScroll>
+		</nav>
+	</main>
+	<MainFooter />
 </Layout>
 
 

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -21,7 +21,6 @@ import Button from '@components/elements/Button.astro';
 import Icon from '@components/elements/Icon.astro';
 import PostMetadata from '@components/elements/PostMetadata.astro';
 import Heading from '@components/blocks/Heading.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 import MainNav from '@components/navigation/MainNav.astro';
 import MainFooter from '@components/navigation/MainFooter.astro';
 import BlockList from '@components/BlockList.astro';
@@ -86,10 +85,7 @@ const postList = page.data.map(({
 						class="post"
 						id={post.uid}
 					>
-						<RevealOnScroll
-							tag="header"
-							class="post-header"
-						>
+						<header class="post-header">
 							{prismicHelpers.isFilled.title(post.title) && (
 								<Heading level={2} class="post-title">
 									<a
@@ -104,7 +100,7 @@ const postList = page.data.map(({
 								<Heading subheading level={3}>{prismicHelpers.asText(post.subtitle)}</Heading>
 							)}
 							<PostMetadata {...post} class="post-date | content-width" />
-						</RevealOnScroll>
+						</header>
 						<BlockList body={post.summary} showLedeStyle />
 						{(post.readMore || post.link) && (
 							<footer class="post-footer">
@@ -134,10 +130,7 @@ const postList = page.data.map(({
 			))}
 		</ul>
 		<nav class="border-seam-top">
-			<RevealOnScroll
-				tag="ul"
-				class="nav-list"
-			>
+			<ul class="nav-list">
 				{prev && (
 					<li class="nav-item">
 						<a
@@ -160,7 +153,7 @@ const postList = page.data.map(({
 						</a>
 					</li>
 				)}
-			</RevealOnScroll>
+			</ul>
 		</nav>
 	</main>
 	<MainFooter />

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -78,7 +78,10 @@ const postList = page.data.map(({
 <Layout pageTitle="Blog">
 	<MainNav segment="blog" />
 	<main>
-		<ul class="post-list" aria-role="feed">
+		<ul
+			class="post-list"
+			role="feed"
+		>
 			{postList.map((post, index) => (
 				<li class={index > 0 ? 'border-seam-top' : ''}>
 					<article

--- a/src/pages/blog/stages/[stage].astro
+++ b/src/pages/blog/stages/[stage].astro
@@ -16,13 +16,15 @@ import {
 
 // components
 import Layout from '@layouts/BaseLayout.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
-import BlogListings from '@components/navigation/BlogListings.astro';
-import BlogListingsPost from '@components/navigation/BlogListingsPost.astro';
-import SequenceNav from '@components/navigation/SequenceNav.astro';
-import SequenceNavItem from '@components/navigation/SequenceNavItem.astro';
 import Heading from '@components/blocks/Heading.astro';
 import Passage from '@components/blocks/Passage.astro';
+import BlogListings from '@components/navigation/BlogListings.astro';
+import BlogListingsPost from '@components/navigation/BlogListingsPost.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
+import SequenceNav from '@components/navigation/SequenceNav.astro';
+import SequenceNavItem from '@components/navigation/SequenceNavItem.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
 import {
@@ -142,7 +144,8 @@ const {
 	pageTitle={sentenceCase(stage)}
 	path="blog"
 >
-	<div class="wrapper">
+	<MainNav segment="blog" />
+	<main class="wrapper">
 		<RevealOnScroll tag="nav">
 			<SequenceNav>
 				{stages.map((item, index) => (
@@ -164,7 +167,6 @@ const {
 			<Passage
 				class="intro"
 				text={description}
-				typeFace="accent"
 				typeSize="delta"
 			/>
 		</RevealOnScroll>
@@ -175,7 +177,8 @@ const {
 				</li>
 			))}
 		</BlogListings>
-	</div>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>
@@ -190,10 +193,6 @@ const {
 
 	.wrapper > :global(* + *) {
 		margin-block-start: var(--space-wide);
-	}
-
-	.intro {
-		color: var(--color-secondary);
 	}
 
 	.post-list {

--- a/src/pages/blog/stages/[stage].astro
+++ b/src/pages/blog/stages/[stage].astro
@@ -24,7 +24,6 @@ import MainFooter from '@components/navigation/MainFooter.astro';
 import MainNav from '@components/navigation/MainNav.astro';
 import SequenceNav from '@components/navigation/SequenceNav.astro';
 import SequenceNavItem from '@components/navigation/SequenceNavItem.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
 import {
@@ -146,7 +145,7 @@ const {
 >
 	<MainNav segment="blog" />
 	<main class="wrapper">
-		<RevealOnScroll tag="nav">
+		<nav>
 			<SequenceNav>
 				{stages.map((item, index) => (
 					<SequenceNavItem
@@ -158,18 +157,16 @@ const {
 					</SequenceNavItem>
 				))}
 			</SequenceNav>
-		</RevealOnScroll>
-		<RevealOnScroll tag="header">
+		</nav>
+		<header class="headline">
 			<Heading level={3} subheading>{prismicHelpers.asText(subtitle)}:</Heading>
 			<Heading level={1}>{sentenceCase(stage)}</Heading>
-		</RevealOnScroll>
-		<RevealOnScroll>
-			<Passage
-				class="intro"
-				text={description}
-				typeSize="delta"
-			/>
-		</RevealOnScroll>
+		</header>
+		<Passage
+			class="intro"
+			text={description}
+			typeSize="delta"
+		/>
 		<BlogListings class="post-list">
 			{posts.map((post) => (
 				<li class="post">
@@ -193,6 +190,12 @@ const {
 
 	.wrapper > :global(* + *) {
 		margin-block-start: var(--space-wide);
+	}
+
+	.headline {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-xxnarrow);
 	}
 
 	.post-list {

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -101,10 +101,10 @@ const {
 <Layout pageTitle={sentenceCase(tag)}>
 	<MainNav segment="blog" />
 	<main class="wrapper">
-		<RevealOnScroll tag="header">
+		<header class="headline">
 			<Heading subheading level={3}>Posts filed under</Heading>
 			<Heading level={1}>{sentenceCase(tag)}</Heading>
-		</RevealOnScroll>
+		</header>
 		<BlogListings class="post-list">
 			{posts.map((post) => (
 				<li class="post">
@@ -126,8 +126,11 @@ const {
 		margin-inline: auto;
 	}
 
-	header {
+	.headline {
 		padding-block-end: var(--space-medium);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-xxnarrow);
 	}
 
 	.post-list {

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -14,7 +14,8 @@ import Heading from '@components/blocks/Heading.astro';
 import Layout from '@layouts/BaseLayout.astro';
 import BlogListings from '@components/navigation/BlogListings.astro';
 import BlogListingsPost from '@components/navigation/BlogListingsPost.astro';
-import ReadNextLink from '@components/navigation/ReadNextLink.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
@@ -97,11 +98,9 @@ const {
 } = Astro.props as Props;
 ---
 
-<Layout
-	pageTitle={sentenceCase(tag)}
-	path="blog"
->
-	<div class="wrapper">
+<Layout pageTitle={sentenceCase(tag)}>
+	<MainNav segment="blog" />
+	<main class="wrapper">
 		<RevealOnScroll tag="header">
 			<Heading subheading level={3}>Posts filed under</Heading>
 			<Heading level={1}>{sentenceCase(tag)}</Heading>
@@ -113,7 +112,8 @@ const {
 				</li>
 			))}
 		</BlogListings>
-	</div>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -124,10 +124,7 @@ let books = await Promise.all(booksResponse.map(async ({
 >
 	<MainNav segment="bookshelf" />
 	<main>
-		<RevealOnScroll
-			class="header"
-			tag="header"
-		>
+		<header class="headline">
 			<Heading
 				align="center"
 				level={1}
@@ -141,7 +138,7 @@ let books = await Promise.all(booksResponse.map(async ({
 					text={subtitle}
 				/>
 			)}
-		</RevealOnScroll>
+		</header>
 
 		<BlockList {body} showLedeStyle />
 
@@ -157,9 +154,7 @@ let books = await Promise.all(booksResponse.map(async ({
 							class="book"
 							title={book.title}
 							author={book.author}
-							cover={{
-								src: book.cover,
-							}}
+							cover={{ src: book.cover }}
 							actions={book.actions}
 						>
 							{book.publisher && book.publishDate && (
@@ -180,14 +175,14 @@ let books = await Promise.all(booksResponse.map(async ({
 </Layout>
 
 <style>
-	.header,
+	.headline,
 	.wrapper {
 		margin-inline: auto;
 		padding-block-start: var(--space-xwide);
 		padding-inline: var(--space-outside);
 	}
 
-	.header {
+	.headline {
 		max-width: var(--content-width-wide);
 		padding-block-end: var(--space-wide);
 	}

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -15,6 +15,8 @@ import Heading from '@components/blocks/Heading.astro';
 import BookCard from '@components/layout/BookCard.astro';
 import Gallery from '@components/layout/Gallery.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
+import MainNav from '@components/navigation/MainNav.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
 import BlockList from '@components/BlockList.astro';
 
 // --- layout
@@ -120,57 +122,61 @@ let books = await Promise.all(booksResponse.map(async ({
 	path="bookshelf"
 	{seo}
 >
-	<RevealOnScroll
-		class="header"
-		tag="header"
-	>
-		<Heading
-			align="center"
-			level={1}
-			text={title}
-		/>
-		{subtitle && (
+	<MainNav segment="bookshelf" />
+	<main>
+		<RevealOnScroll
+			class="header"
+			tag="header"
+		>
 			<Heading
 				align="center"
-				level={4}
-				subheading
-				text={subtitle}
+				level={1}
+				text={title}
 			/>
-		)}
-	</RevealOnScroll>
+			{subtitle && (
+				<Heading
+					align="center"
+					level={4}
+					subheading
+					text={subtitle}
+				/>
+			)}
+		</RevealOnScroll>
 
-	<BlockList {body} showLedeStyle />
+		<BlockList {body} showLedeStyle />
 
-	<div class="wrapper">
-		<Gallery gutter="wide">
-			{books.map((book) => (
-				<li
-					class="item"
-					data-tags={book.tags.join(' ')}
-					id={book.uid}
-				>
-					<BookCard
-						class="book"
-						title={book.title}
-						author={book.author}
-						cover={{
-							src: book.cover,
-						}}
-						actions={book.actions}
+		<div class="wrapper">
+			<Gallery gutter="wide">
+				{books.map((book) => (
+					<li
+						class="item"
+						data-tags={book.tags.join(' ')}
+						id={book.uid}
 					>
-						{book.publisher && book.publishDate && (
-							<p
-								slot="metadata"
-								class="metadata type-role-accent type-scale-zeta"
-							>
-								{[book.publisher, book.publishDate].join(', ')}
-							</p>
-						)}
-					</BookCard>
-				</li>
-			))}
-		</Gallery>
-	</div>
+						<BookCard
+							class="book"
+							title={book.title}
+							author={book.author}
+							cover={{
+								src: book.cover,
+							}}
+							actions={book.actions}
+						>
+							{book.publisher && book.publishDate && (
+								<p
+									slot="metadata"
+									class="metadata type-role-accent type-scale-zeta"
+								>
+									{[book.publisher, book.publishDate].join(', ')}
+								</p>
+							)}
+						</BookCard>
+					</li>
+				))}
+			</Gallery>
+		</div>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>

--- a/src/pages/design.astro
+++ b/src/pages/design.astro
@@ -11,8 +11,10 @@ import prismic from '@lib/prismic';
 
 // components
 import Layout from '@layouts/BaseLayout.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 import Heading from '@components/blocks/Heading.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
+import MainNav from '@components/navigation/MainNav.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
 import BlockList from '@components/BlockList.astro';
 
 // fetch content
@@ -41,16 +43,19 @@ const seo = {
 	path="design"
 	{seo}
 >
-	<article>
-		<RevealOnScroll tag="header">
-			<Heading level={1}>{prismicHelpers.asText(title)}</Heading>
-			{subtitle && (
-				<Heading level={3} subheading>{prismicHelpers.asText(subtitle)}</Heading>
-			)}
-		</RevealOnScroll>
-
-		<BlockList {body} showLedeStyle />
-	</article>
+	<MainNav segment="design" />
+	<main>
+		<article>
+			<RevealOnScroll tag="header">
+				<Heading level={1}>{prismicHelpers.asText(title)}</Heading>
+				{subtitle && (
+					<Heading level={3} subheading>{prismicHelpers.asText(subtitle)}</Heading>
+				)}
+			</RevealOnScroll>
+			<BlockList {body} showLedeStyle />
+		</article>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>

--- a/src/pages/design.astro
+++ b/src/pages/design.astro
@@ -46,12 +46,12 @@ const seo = {
 	<MainNav segment="design" />
 	<main>
 		<article>
-			<RevealOnScroll tag="header">
+			<header class="headline">
 				<Heading level={1}>{prismicHelpers.asText(title)}</Heading>
 				{subtitle && (
 					<Heading level={3} subheading>{prismicHelpers.asText(subtitle)}</Heading>
 				)}
-			</RevealOnScroll>
+			</header>
 			<BlockList {body} showLedeStyle />
 		</article>
 	</main>
@@ -63,7 +63,7 @@ const seo = {
 		padding-block: var(--space-xwide);
 	}
 
-	header {
+	.headline {
 		padding-block-end: var(--space-wide);
 		padding-inline: var(--space-outside);
 		text-align: center;

--- a/src/pages/design/[year]/[uid].astro
+++ b/src/pages/design/[year]/[uid].astro
@@ -159,29 +159,25 @@ const credits = [
 	<MainNav segment="design" />
 	<main>
 		<article>
-			<RevealOnScroll
-				class="headline"
-				tag="header"
-			>
+			<header class="headline">
 				<Heading level={1}>{prismicHelpers.asText(title)}</Heading>
 				{client && (
 					<Heading subheading level={3}>{client}</Heading>
 				)}
-			</RevealOnScroll>
+			</header>
+
 			<BlockList {body} showLedeStyle />
-			<RevealOnScroll
-				tag="aside"
-				class="border-seam-top credits"
-			>
+
+			<aside class="border-seam-top credits">
 				<div class="credits-wrapper">
 					<Heading level={2} class="credits-heading">Credits</Heading>
 					<DataGrid data={credits} />
 				</div>
-			</RevealOnScroll>
+			</aside>
 		</article>
 		{next && (
 			<nav class="border-seam-top">
-				<RevealOnScroll class="nav-wrapper">
+				<div class="nav-wrapper">
 					<ReadNextLink
 						align="end"
 						link={next.path}
@@ -190,7 +186,7 @@ const credits = [
 						<Fragment slot="eyebrow">Next case study:</Fragment>
 						<Fragment slot="title">{prismicHelpers.asText(next.title)}</Fragment>
 					</ReadNextLink>
-				</RevealOnScroll>
+				</div>
 			</nav>
 		)}
 	</main>

--- a/src/pages/design/[year]/[uid].astro
+++ b/src/pages/design/[year]/[uid].astro
@@ -5,11 +5,13 @@ import '@styles/tokens/contentWidth.css';
 import '@styles/utilities/borders.css';
 
 // components
-import BlockList from '@components/BlockList.astro';
-import DataGrid from '@components/layout/DataGrid.astro';
-import Heading from '@components/blocks/Heading.astro';
 import Layout from '@layouts/BaseLayout.astro';
+import BlockList from '@components/BlockList.astro';
+import Heading from '@components/blocks/Heading.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
 import ReadNextLink from '@components/navigation/ReadNextLink.astro';
+import DataGrid from '@components/layout/DataGrid.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // utilities
@@ -154,41 +156,45 @@ const credits = [
 	path="design"
 	{seo}
 >
-	<article>
-		<RevealOnScroll tag="header">
-			<Heading level={1}>{prismicHelpers.asText(title)}</Heading>
-			{client && (
-				<Heading subheading level={3}>{client}</Heading>
-			)}
-		</RevealOnScroll>
-
-		<BlockList {body} showLedeStyle />
-
-		<RevealOnScroll
-			tag="aside"
-			class="border-seam-top credits"
-		>
-			<div class="credits-wrapper">
-				<Heading level={2} class="credits-heading">Credits</Heading>
-				<DataGrid data={credits} />
-			</div>
-		</RevealOnScroll>
-	</article>
-
-	{next && (
-		<nav class="border-seam-top">
-			<RevealOnScroll class="nav-wrapper">
-				<ReadNextLink
-					align="end"
-					link={next.path}
-					titleSize="beta"
-				>
-					<Fragment slot="eyebrow">Next case study:</Fragment>
-					<Fragment slot="title">{prismicHelpers.asText(next.title)}</Fragment>
-				</ReadNextLink>
+	<MainNav segment="design" />
+	<main>
+		<article>
+			<RevealOnScroll
+				class="headline"
+				tag="header"
+			>
+				<Heading level={1}>{prismicHelpers.asText(title)}</Heading>
+				{client && (
+					<Heading subheading level={3}>{client}</Heading>
+				)}
 			</RevealOnScroll>
-		</nav>
-	)}
+			<BlockList {body} showLedeStyle />
+			<RevealOnScroll
+				tag="aside"
+				class="border-seam-top credits"
+			>
+				<div class="credits-wrapper">
+					<Heading level={2} class="credits-heading">Credits</Heading>
+					<DataGrid data={credits} />
+				</div>
+			</RevealOnScroll>
+		</article>
+		{next && (
+			<nav class="border-seam-top">
+				<RevealOnScroll class="nav-wrapper">
+					<ReadNextLink
+						align="end"
+						link={next.path}
+						titleSize="beta"
+					>
+						<Fragment slot="eyebrow">Next case study:</Fragment>
+						<Fragment slot="title">{prismicHelpers.asText(next.title)}</Fragment>
+					</ReadNextLink>
+				</RevealOnScroll>
+			</nav>
+		)}
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>
@@ -196,16 +202,15 @@ const credits = [
 		padding-block-end: var(--space-xwide);
 	}
 
-	header {
+	.headline {
 		max-width: var(--content-width-xwide);
 		margin-inline: auto;
 		padding-block-start: var(--space-wide);
 		padding-block-end: var(--space-xwide);
 		text-align: center;
-	}
-
-	header > * + * {
-		padding-block-start: var(--space-xxnarrow);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-xxnarrow);
 	}
 
 	.credits {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ const seo = {
 
 	<main>
 		<!-- intro -->
-		<header class="cover">
+		<section class="cover">
 			<RevealOnScroll class="intro">
 				<div class="blurb">
 					<Heading
@@ -71,12 +71,12 @@ const seo = {
 					</div>
 				</div>
 			</RevealOnScroll>
-		</header>
+		</section>
 
 		<!-- TOC panels -->
-		<div id="toc">
+		<section id="toc">
 			<BlockList {body} numbered />
-		</div>
+		</section>
 	</main>
 	<MainFooter />
 </Layout>
@@ -110,14 +110,14 @@ const seo = {
 		padding-inline-start: 0;
 	}
 
-	.toc > li {
+	/* .toc > li {
 		display: flex;
 		flex-direction: column;
 		min-height: 100vh;
 		min-height: 100svh;
 		padding-block: var(--space-wide);
 		padding-inline: var(--space-outside);
-	}
+	} */
 
 	.wrapper {
 		display: flex;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,7 +18,6 @@ import BlockList from '@components/BlockList.astro';
 import Button from '@components/elements/Button.astro';
 import Heading from '@components/blocks/Heading.astro';
 import Passage from '@components/blocks/Passage.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 import MainNav from '@components/navigation/MainNav.astro';
 import MainFooter from '@components/navigation/MainFooter.astro';
 
@@ -50,27 +49,25 @@ const seo = {
 	<main>
 		<!-- intro -->
 		<section class="cover">
-			<RevealOnScroll class="intro">
-				<div class="blurb">
-					<Heading
-						level={1}
-						text={headline}
-					/>
-					<Passage
-						text={{ prismicText: intro }}
-						class="blurb"
-						typeSize="delta"
-					/>
-					<div class="blurb-cta">
-						<Button
-							href={introLink}
-							iconRight={arrowRight}
-						>
-							A bit more about me
-						</Button>
-					</div>
+			<div class="blurb">
+				<Heading
+					level={1}
+					text={headline}
+				/>
+				<Passage
+					text={{ prismicText: intro }}
+					class="blurb"
+					typeSize="delta"
+				/>
+				<div class="blurb-cta">
+					<Button
+						href={introLink}
+						iconRight={arrowRight}
+					>
+						A bit more about me
+					</Button>
 				</div>
-			</RevealOnScroll>
+			</div>
 		</section>
 
 		<!-- TOC panels -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,6 @@ import '@styles/tokens/contentWidth.css';
 import '@styles/tokens/spacing.css';
 import '@styles/utilities/borders.css';
 import '@styles/utilities/type.css';
-import arrowDown from '@icons/arrow-down.svg?raw';
 import arrowRight from '@icons/arrow-right.svg?raw';
 
 // utils
@@ -17,10 +16,11 @@ import { linkResolver, fetchLinks } from '@lib/routes';
 import Layout from '@layouts/BaseLayout.astro';
 import BlockList from '@components/BlockList.astro';
 import Button from '@components/elements/Button.astro';
-import Icon from '@components/elements/Icon.astro';
 import Heading from '@components/blocks/Heading.astro';
 import Passage from '@components/blocks/Passage.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
+import MainNav from '@components/navigation/MainNav.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
 
 // fetch content
 const response = await prismic.getSingle('homepage', { fetchLinks });
@@ -44,60 +44,46 @@ const seo = {
 };
 ---
 
-<Layout
-	path="home"
-	overlayNav
-	{seo}
->
-	<!-- intro -->
-	<header>
-		<RevealOnScroll class="intro">
-			<div class="blurb">
-				<Heading
-					level={1}
-					text={headline}
-				/>
-				<Passage
-					text={{ prismicText: intro }}
-					class="blurb"
-					typeSize="delta"
-				/>
-				<div class="blurb-cta">
-					<Button
-						href={introLink}
-						iconRight={arrowRight}
-					>
-						A bit more about me
-					</Button>
-				</div>
-			</div>
-			<a
-				class="toc-link type-role-accent type-scale-epsilon type-link-undecorated"
-				href="#toc"
-			>
-				<Icon
-					align="baseline"
-					margin="right"
-					svg={arrowDown}
-				/>
-				Table of contents
-			</a>
-		</RevealOnScroll>
-	</header>
+<Layout {seo}>
+	<MainNav segment='home' />
 
-	<!-- TOC panels -->
-	<div id="toc">
-		<BlockList {body} numbered />
-	</div>
+	<main>
+		<!-- intro -->
+		<header class="cover">
+			<RevealOnScroll class="intro">
+				<div class="blurb">
+					<Heading
+						level={1}
+						text={headline}
+					/>
+					<Passage
+						text={{ prismicText: intro }}
+						class="blurb"
+						typeSize="delta"
+					/>
+					<div class="blurb-cta">
+						<Button
+							href={introLink}
+							iconRight={arrowRight}
+						>
+							A bit more about me
+						</Button>
+					</div>
+				</div>
+			</RevealOnScroll>
+		</header>
+
+		<!-- TOC panels -->
+		<div id="toc">
+			<BlockList {body} numbered />
+		</div>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>
-	header {
-		display: flex;
-		min-height: 100vh;
-		min-height: 100svh;
-		padding-block-end: var(--space-narrow);
-		padding-block-start: var(--space-wide);
+	.cover {
+		padding-block: var(--space-xwide);
 		padding-inline: var(--space-outside);
 	}
 
@@ -111,17 +97,12 @@ const seo = {
 		max-width: var(--content-width-xxwide);
 	}
 
-
 	.blurb > :global(* + *) {
 		padding-block-start: var(--space-medium);
 	}
 
 	.blurb-cta {
 		padding-block-start: var(--space-wide);
-	}
-
-	.toc-link {
-		color: var(--color-secondary);
 	}
 
 	.toc {
@@ -133,6 +114,7 @@ const seo = {
 		display: flex;
 		flex-direction: column;
 		min-height: 100vh;
+		min-height: 100svh;
 		padding-block: var(--space-wide);
 		padding-inline: var(--space-outside);
 	}

--- a/src/pages/longform/[year]/[uid]/[page].astro
+++ b/src/pages/longform/[year]/[uid]/[page].astro
@@ -19,7 +19,6 @@ import MainNav from '@components/navigation/MainNav.astro';
 import ReadNextLink from '@components/navigation/ReadNextLink.astro';
 import SequenceNav from '@components/navigation/SequenceNav.astro';
 import SequenceNavItem from '@components/navigation/SequenceNavItem.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
 import type {
@@ -227,7 +226,7 @@ const nextChapter = project.chapterList[currentPage] ? {
 		<article>
 			<!-- titling -->
 			<header class="headline">
-				<RevealOnScroll class="wrapper wide">
+				<div class="wrapper wide">
 					<!-- project title -->
 					<Heading level={1} text={project.title} />
 					{project.subtitle && <Heading level={1} subheading text={project.subtitle} />}
@@ -243,14 +242,16 @@ const nextChapter = project.chapterList[currentPage] ? {
 					<Heading level={3} subheading>{`${project.chapterLabel} ${currentPage}`}</Heading>
 					<Heading level={2} class="header-chapter" text={title} />
 					{subtitle && <Heading level={3} class="header-chapter" subheading text={subtitle} />}
-				</RevealOnScroll>
+				</div>
 			</header>
+
 			<!-- body -->
 			<BlockList {body} showLedeStyle />
 		</article>
+
 		<!-- sequence nav -->
 		<nav class="footer-nav">
-			<RevealOnScroll class="wrapper">
+			<div class="wrapper">
 				<SequenceNav>
 					{sequenceNavItems.map((item) => (
 						<SequenceNavItem {...item} next={item.href === url.next}>
@@ -275,7 +276,7 @@ const nextChapter = project.chapterList[currentPage] ? {
 							</aside>
 					}
 				</div>
-			</RevealOnScroll>
+			</div>
 		</nav>
 	</main>
 

--- a/src/pages/longform/[year]/[uid]/[page].astro
+++ b/src/pages/longform/[year]/[uid]/[page].astro
@@ -10,14 +10,16 @@ import * as prismicHelpers from '@prismicio/helpers';
 import prismic from '@lib/prismic';
 
 // components
+import Layout from '@layouts/BaseLayout.astro';
 import BlockList from '@components/BlockList.astro';
 import Callout from '@components/elements/Callout.astro';
 import Heading from '@components/blocks/Heading.astro';
-import Layout from '@layouts/BaseLayout.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
 import ReadNextLink from '@components/navigation/ReadNextLink.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 import SequenceNav from '@components/navigation/SequenceNav.astro';
 import SequenceNavItem from '@components/navigation/SequenceNavItem.astro';
+import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // types
 import type {
@@ -216,98 +218,94 @@ const nextChapter = project.chapterList[currentPage] ? {
 ---
 
 <Layout
-	path={uid}
 	pageTitle={prismicHelpers.asText(project.title)}
 	theme={generatePageTheme()}
 	{seo}
 >
-	<article>
-
-		<!-- titling -->
-		<header>
-			<RevealOnScroll class="wrapper wide">
-
-				<!-- project title -->
-				<Heading level={1} text={project.title} />
-				{project.subtitle && <Heading level={1} subheading text={project.subtitle} />}
-
-				<!-- sequence nav -->
-				<div class="header-nav | wrapper">
-					<SequenceNav>
-						{sequenceNavItems.map((item) => (
-							<SequenceNavItem {...item}>{prismicHelpers.asText(item.title)}</SequenceNavItem>
-						))}
-					</SequenceNav>
+	<MainNav segment={uid} />
+	<main>
+		<article>
+			<!-- titling -->
+			<header class="headline">
+				<RevealOnScroll class="wrapper wide">
+					<!-- project title -->
+					<Heading level={1} text={project.title} />
+					{project.subtitle && <Heading level={1} subheading text={project.subtitle} />}
+					<!-- sequence nav -->
+					<div class="header-nav | wrapper">
+						<SequenceNav>
+							{sequenceNavItems.map((item) => (
+								<SequenceNavItem {...item}>{prismicHelpers.asText(item.title)}</SequenceNavItem>
+							))}
+						</SequenceNav>
+					</div>
+					<!-- chapter title -->
+					<Heading level={3} subheading>{`${project.chapterLabel} ${currentPage}`}</Heading>
+					<Heading level={2} class="header-chapter" text={title} />
+					{subtitle && <Heading level={3} class="header-chapter" subheading text={subtitle} />}
+				</RevealOnScroll>
+			</header>
+			<!-- body -->
+			<BlockList {body} showLedeStyle />
+		</article>
+		<!-- sequence nav -->
+		<nav class="footer-nav">
+			<RevealOnScroll class="wrapper">
+				<SequenceNav>
+					{sequenceNavItems.map((item) => (
+						<SequenceNavItem {...item} next={item.href === url.next}>
+							{prismicHelpers.asText(item.title)}
+						</SequenceNavItem>
+					))}
+				</SequenceNav>
+				<div class="next">
+					{nextChapter
+						? <ReadNextLink
+								align="end"
+								class="next"
+								eyebrowSize="gamma"
+								link={nextChapter.href}
+								titleSize="beta"
+							>
+								<Fragment slot="eyebrow">{`${project.chapterLabel} ${currentPage + 1}`}</Fragment>
+								<Fragment slot="title">{prismicHelpers.asText(nextChapter.title)}</Fragment>
+							</ReadNextLink>
+						: <aside class="end | type-role-display type-scale-gamma">
+								The end
+							</aside>
+					}
 				</div>
-
-				<!-- chapter title -->
-				<Heading level={3} subheading>{`${project.chapterLabel} ${currentPage}`}</Heading>
-				<Heading level={2} class="header-chapter" text={title} />
-				{subtitle && <Heading level={3} class="header-chapter" subheading text={subtitle} />}
 			</RevealOnScroll>
-		</header>
+		</nav>
+	</main>
 
-		<!-- body -->
-		<BlockList {body} showLedeStyle />
-	</article>
-
-	<!-- sequence nav -->
-	<nav class="footer-nav">
-		<RevealOnScroll class="wrapper">
-			<SequenceNav>
-				{sequenceNavItems.map((item) => (
-					<SequenceNavItem {...item} next={item.href === url.next}>
-						{prismicHelpers.asText(item.title)}
-					</SequenceNavItem>
+	<!-- Callouts -->
+		{callouts?.length > 0 && (
+			<div class="support">
+				{callouts.map((callout: Callout) => (
+					<Callout
+						{...callout}
+						class="support-box"
+					/>
 				))}
-			</SequenceNav>
-
-			<div class="next">
-				{nextChapter
-					? <ReadNextLink
-							align="end"
-							class="next"
-							eyebrowSize="gamma"
-							link={nextChapter.href}
-							titleSize="beta"
-						>
-							<Fragment slot="eyebrow">{`${project.chapterLabel} ${currentPage + 1}`}</Fragment>
-							<Fragment slot="title">{prismicHelpers.asText(nextChapter.title)}</Fragment>
-						</ReadNextLink>
-					: <aside class="end | type-role-display type-scale-gamma">
-							The end
-						</aside>
-				}
 			</div>
-		</RevealOnScroll>
-	</nav>
-
-	{callouts?.length > 0 && (
-		<div class="support">
-			{callouts.map((callout: Callout) => (
-				<Callout
-					{...callout}
-					class="support-box"
-				/>
-			))}
-		</div>
-	)}
+		)}
+		<MainFooter />
 </Layout>
 
 <style>
 	article {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-xwide);
 		padding-block: var(--space-xwide);
 	}
 
-	article > * + * {
-		padding-block-start: var(--space-xwide);
-	}
-
-	header {
+	.headline {
 		text-align: center;
 	}
 
-	header,
+	.headline,
 	.footer-nav {
 		padding-inline: var(--space-outside);
 	}

--- a/src/pages/pictures.astro
+++ b/src/pages/pictures.astro
@@ -16,7 +16,6 @@ import Layout from '@layouts/BaseLayout.astro';
 import MainFooter from '@components/navigation/MainFooter.astro';
 import MainNav from '@components/navigation/MainNav.astro';
 import PictureGallery from '@components/navigation/PictureGallery.astro';
-import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
 // --- data
 // use this aspect ratio when none is specified for a given series
@@ -105,12 +104,11 @@ picturesBySeries.push({
 >
 	<MainNav segment="pictures" />
 	<main>
-		<RevealOnScroll class="title">
-			<Heading
-				level={1}
-				text={title}
-			/>
-		</RevealOnScroll>
+		<Heading
+			class="title"
+			level={1}
+			text={title}
+		/>
 
 		{picturesBySeries.map((series) => (
 			<section
@@ -118,16 +116,15 @@ picturesBySeries.push({
 				class="series"
 				id={series.uid || 'other-work'}
 			>
-				<RevealOnScroll>
-					<Heading level={2} class="series-title type-scale-gamma">
-						{series.title
-							? <Fragment>
-									{prismicHelpers.asText(series.title)} series
-								</Fragment>
-							: <Fragment>Other recent work</Fragment>
-						}
-					</Heading>
-				</RevealOnScroll>
+				<Heading
+					level={2}
+					class="series-title type-scale-gamma"
+				>
+					{series.title
+						? `${prismicHelpers.asText(series.title)} series`
+						: 'Other recent work'
+					}
+				</Heading>
 
 				<PictureGallery
 					list={series.pictures as PrismicDocumentWithUID[]}

--- a/src/pages/pictures.astro
+++ b/src/pages/pictures.astro
@@ -112,7 +112,7 @@ picturesBySeries.push({
 
 		{picturesBySeries.map((series) => (
 			<section
-				aria-role="feed"
+				role="feed"
 				class="series"
 				id={series.uid || 'other-work'}
 			>

--- a/src/pages/pictures.astro
+++ b/src/pages/pictures.astro
@@ -13,6 +13,8 @@ import { PrismicDocumentWithUID } from '@prismicio/types';
 // --- components
 import Heading from '@components/blocks/Heading.astro';
 import Layout from '@layouts/BaseLayout.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
 import PictureGallery from '@components/navigation/PictureGallery.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 
@@ -101,36 +103,40 @@ picturesBySeries.push({
 	path="pictures"
 	{seo}
 >
-	<RevealOnScroll class="title">
-		<Heading
-			level={1}
-			text={title}
-		/>
-	</RevealOnScroll>
-
-	{picturesBySeries.map((series) => (
-		<section
-			aria-role="feed"
-			class="series"
-			id={series.uid || 'other-work'}
-		>
-			<RevealOnScroll>
-				<Heading level={2} class="series-title type-scale-gamma">
-					{series.title
-						? <Fragment>
-								{prismicHelpers.asText(series.title)} series
-							</Fragment>
-						: <Fragment>Other recent work</Fragment>
-					}
-				</Heading>
-			</RevealOnScroll>
-
-			<PictureGallery
-				list={series.pictures as PrismicDocumentWithUID[]}
-				aspectRatio={series.aspectRatio}
+	<MainNav segment="pictures" />
+	<main>
+		<RevealOnScroll class="title">
+			<Heading
+				level={1}
+				text={title}
 			/>
-		</section>
-	))}
+		</RevealOnScroll>
+
+		{picturesBySeries.map((series) => (
+			<section
+				aria-role="feed"
+				class="series"
+				id={series.uid || 'other-work'}
+			>
+				<RevealOnScroll>
+					<Heading level={2} class="series-title type-scale-gamma">
+						{series.title
+							? <Fragment>
+									{prismicHelpers.asText(series.title)} series
+								</Fragment>
+							: <Fragment>Other recent work</Fragment>
+						}
+					</Heading>
+				</RevealOnScroll>
+
+				<PictureGallery
+					list={series.pictures as PrismicDocumentWithUID[]}
+					aspectRatio={series.aspectRatio}
+				/>
+			</section>
+		))}
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>

--- a/src/pages/pictures/[year]/[month]/[uid].astro
+++ b/src/pages/pictures/[year]/[month]/[uid].astro
@@ -272,10 +272,7 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 	<MainNav segment="pictures" />
 	<main>
 		<!-- cover -->
-		<RevealOnScroll
-			tag="header"
-			class="cover"
-		>
+		<header class="cover">
 			<PictureFrame
 				source={cover as ImageField}
 				class="cover-image"
@@ -288,7 +285,7 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 					<p class="cover-info-item media" set:html={createMediaString()}></p>
 				)}
 			</div>
-		</RevealOnScroll>
+		</header>
 
 		<!-- back story -->
 		{prismicHelpers.isFilled.sliceZone(body) && (
@@ -300,25 +297,18 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 
 		<!-- editions -->
 		<section class="wrapper | border-seam-top" id="editions">
-			<RevealOnScroll>
-				<Heading level={2} align="center">
-					Available editions
-				</Heading>
-			</RevealOnScroll>
+			<Heading level={2} align="center">
+				Available editions
+			</Heading>
 
 			{editionsByType.map((type) => (
-				<RevealOnScroll>
-					<PrintEdition {type} />
-				</RevealOnScroll>
+				<PrintEdition {type} />
 			))}
 		</section>
 
 		<!-- Footer nav -->
 		<nav class="wrapper | border-seam-top">
-			<RevealOnScroll
-				tag="header"
-				class="nav-header"
-			>
+			<header class="nav-header">
 				{nav.title
 					? <Heading level={2} class="nav-header-title | type-scale-gamma">
 							More from the <strong>{prismicHelpers.asText(nav.title)}</strong>&nbsp;series
@@ -331,7 +321,7 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 				>
 					See all
 				</Button>
-			</RevealOnScroll>
+			</header>
 			<PictureGallery
 				aspectRatio={nav.aspectRatio}
 				list={nav.pictures as PrismicDocumentWithUID[]}

--- a/src/pages/pictures/[year]/[month]/[uid].astro
+++ b/src/pages/pictures/[year]/[month]/[uid].astro
@@ -21,6 +21,8 @@ import BlockList from '@components/BlockList.astro';
 import Button from '@components/elements/Button.astro';
 import PictureFrame from '@components/elements/PictureFrame.astro';
 import Heading from '@components/blocks/Heading.astro';
+import MainFooter from '@components/navigation/MainFooter.astro';
+import MainNav from '@components/navigation/MainNav.astro';
 import RevealOnScroll from '@components/layout/RevealOnScroll.astro';
 import PrintEdition from '@components/layout/PrintEdition.astro';
 import PictureGallery from '@components/navigation/PictureGallery.astro';
@@ -267,72 +269,76 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 	path="pictures"
 	{seo}
 >
-	<!-- cover -->
-	<RevealOnScroll
-		tag="header"
-		class="cover"
-	>
-		<PictureFrame
-			source={cover as ImageField}
-			class="cover-image"
-			type={substrateName.includes('paper') ? 'frame' : 'panel'}
-		/>
-		<div class="cover-info | type-scale-epsilon type-role-accent">
-			<Heading level={1} text={title} class="cover-info-item title" />
-			<time class="cover-info-item year" datetime={date.toString()}>{format(new Date(date), 'yyyy')}</time>
-			{prismicHelpers.isFilled.group(media) && (
-				<p class="cover-info-item media" set:html={createMediaString()}></p>
-			)}
-		</div>
-	</RevealOnScroll>
-
-	<!-- back story -->
-	{prismicHelpers.isFilled.sliceZone(body) && (
-		<section class="wrapper | border-seam-top" id="backstory">
-			<Heading level={2} align="center">Back story</Heading>
-			<BlockList {body} />
-		</section>
-	)}
-
-	<!-- editions -->
-	<section class="wrapper | border-seam-top" id="editions">
-		<RevealOnScroll>
-			<Heading level={2} align="center">
-				Available editions
-			</Heading>
-		</RevealOnScroll>
-
-		{editionsByType.map((type) => (
-			<RevealOnScroll>
-				<PrintEdition {type} />
-			</RevealOnScroll>
-		))}
-	</section>
-
-	<!-- Footer nav -->
-	<nav class="wrapper | border-seam-top">
+	<MainNav segment="pictures" />
+	<main>
+		<!-- cover -->
 		<RevealOnScroll
 			tag="header"
-			class="nav-header"
+			class="cover"
 		>
-			{nav.title
-				? <Heading level={2} class="nav-header-title | type-scale-gamma">
-						More from the <strong>{prismicHelpers.asText(nav.title)}</strong>&nbsp;series
-					</Heading>
-				: <Heading level={2} class="">More work</Heading>
-			}
-			<Button
-				href={indexPage({ uid: 'pictures' } as PrismicDocument)}
-				iconRight={index}
-			>
-				See all
-			</Button>
+			<PictureFrame
+				source={cover as ImageField}
+				class="cover-image"
+				type={substrateName.includes('paper') ? 'frame' : 'panel'}
+			/>
+			<div class="cover-info | type-scale-epsilon type-role-accent">
+				<Heading level={1} text={title} class="cover-info-item title" />
+				<time class="cover-info-item year" datetime={date.toString()}>{format(new Date(date), 'yyyy')}</time>
+				{prismicHelpers.isFilled.group(media) && (
+					<p class="cover-info-item media" set:html={createMediaString()}></p>
+				)}
+			</div>
 		</RevealOnScroll>
-		<PictureGallery
-			aspectRatio={nav.aspectRatio}
-			list={nav.pictures as PrismicDocumentWithUID[]}
-		/>
-	</nav>
+
+		<!-- back story -->
+		{prismicHelpers.isFilled.sliceZone(body) && (
+			<section class="wrapper | border-seam-top" id="backstory">
+				<Heading level={2} align="center">Back story</Heading>
+				<BlockList {body} />
+			</section>
+		)}
+
+		<!-- editions -->
+		<section class="wrapper | border-seam-top" id="editions">
+			<RevealOnScroll>
+				<Heading level={2} align="center">
+					Available editions
+				</Heading>
+			</RevealOnScroll>
+
+			{editionsByType.map((type) => (
+				<RevealOnScroll>
+					<PrintEdition {type} />
+				</RevealOnScroll>
+			))}
+		</section>
+
+		<!-- Footer nav -->
+		<nav class="wrapper | border-seam-top">
+			<RevealOnScroll
+				tag="header"
+				class="nav-header"
+			>
+				{nav.title
+					? <Heading level={2} class="nav-header-title | type-scale-gamma">
+							More from the <strong>{prismicHelpers.asText(nav.title)}</strong>&nbsp;series
+						</Heading>
+					: <Heading level={2} class="">More work</Heading>
+				}
+				<Button
+					href={indexPage({ uid: 'pictures' } as PrismicDocument)}
+					iconRight={index}
+				>
+					See all
+				</Button>
+			</RevealOnScroll>
+			<PictureGallery
+				aspectRatio={nav.aspectRatio}
+				list={nav.pictures as PrismicDocumentWithUID[]}
+			/>
+		</nav>
+	</main>
+	<MainFooter />
 </Layout>
 
 <style>

--- a/src/scripts/SideNote.ts
+++ b/src/scripts/SideNote.ts
@@ -130,7 +130,7 @@ class SideNote extends HTMLElement {
 				<button class="label" aria-label="Toggle the note">${this.number}</button>
 				<small
 					class="content"
-					aria-role="note"
+					role="note"
 				>
 					<span class="wrapper" data-count="${this.number}">
 						<span class="text"><slot></slot></span>


### PR DESCRIPTION
## Description
- Fixed bug where intro content overlaps the header on the homepage
- Refactored the mobile nav so there isn't layout shift as the JS loads
- Lightly reworked the homepage layout to simplify - not happy with it, need to rethink, but it's better
- Reduced use of scroll-based animations to help load times and avoid too much of... all of it
- Moved the header and footer out of `BaseLayout` and into page templates to offer more flexibility/simplify

## Tasks
- []()
