### PR TITLE
Fix book cover positioning

### DIFF
--- a/src/components/layout/BookCard.astro
+++ b/src/components/layout/BookCard.astro
@@ -141,6 +141,7 @@ const {
 		display: flex;
 		grid-area: cover;
 		justify-content: center;
+		justify-self: center;
 	}
 
 	.cover-image {


### PR DESCRIPTION
## Description
- Book covers were aligned left instead of centered - a flexbox/grid/aspect ratio bug?

## Tasks
- [Book covers are not centered …](https://todoist.com/showTask?id=7358433673)
