### PR TITLE
Fix broken main nav layout on iOS Safari

### DIFF
--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -34,9 +34,14 @@ const {
 	segment,
 	class:className = '',
 } = Astro.props as Props;
+
+const classList = [
+	'wrapper',
+	className,
+].join(' ');
 ---
 
-<header class={className}>
+<header class={classList}>
 	<a
 		class="logo p-url"
 		href={Astro.site}
@@ -160,7 +165,7 @@ const {
 
 <style>
 	/* --- layout --- */
-	header {
+	.wrapper {
 		--transition: 0.25s;
 
 		padding-inline: var(--space-outside);

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -36,7 +36,7 @@ const {
 } = Astro.props as Props;
 
 const classList = [
-	'wrapper',
+	'main-header',
 	className,
 ].join(' ');
 ---
@@ -165,7 +165,7 @@ const classList = [
 
 <style>
 	/* --- layout --- */
-	.wrapper {
+	.main-header {
 		--transition: 0.25s;
 
 		padding-inline: var(--space-outside);

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -65,6 +65,7 @@ const {
 	</jp-hamburger-nav>
 </header>
 
+<!-- keep this script inline because we need it immediately -->
 <script is:inline type="module">
 	class HamburgerNav extends HTMLElement {
 		constructor() {
@@ -167,6 +168,7 @@ const {
 		flex-direction: row;
 		align-items: center;
 		justify-content: space-between;
+		width: 100%;
 	}
 
   /* --- nav elements --- */

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -173,7 +173,6 @@ const classList = [
 		flex-direction: row;
 		align-items: center;
 		justify-content: space-between;
-		width: 100%;
 	}
 
   /* --- nav elements --- */

--- a/src/pages/[uid].astro
+++ b/src/pages/[uid].astro
@@ -80,7 +80,7 @@ const {
 	<MainNav segment={uid} />
 	<main>
 		<article>
-			<header>
+			<header class="title">
 				<Heading
 					level={1}
 					text={title}
@@ -104,7 +104,7 @@ const {
     padding-block: var(--space-xwide);
 	}
 
-	header {
+	.title {
 		padding-block-end: var(--space-wide);
 		padding-inline: var(--space-outside);
 		text-align: center;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -109,13 +109,4 @@ const seo = {
 		list-style: none;
 		padding-inline-start: 0;
 	}
-
-	.wrapper {
-		display: flex;
-		flex-direction: column;
-		flex: 1;
-		margin-inline: auto;
-		max-width: var(--content-width-xxwide);
-		width: 100%;
-	}
 </style>


### PR DESCRIPTION
## Description
- Main nav gets stacked in the center on `page` templates - possibly a side effect of the flexbox applied to the `body` tag?
- Trying `width: 100%` on nav container to see if that forces it to stay full-width.

## Tasks
- []()
