### PR TITLE
Bug fixes: Font style linking, sidenote styling, icon stroke widths

### DIFF
--- a/public/assets/icons/arrow-left.svg
+++ b/public/assets/icons/arrow-left.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M9.875 15.625L.875 8l9-7.625"/><path stroke-linecap="square" d="M15.5 8h-14"/></g></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M9.875 15.625L.875 8l9-7.625"/><path stroke-linecap="square" d="M15.5 8h-14"/></g></svg>

--- a/public/assets/icons/arrow-right.svg
+++ b/public/assets/icons/arrow-right.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M6 15.625L15 8 6 .375"/><path stroke-linecap="square" d="M14 8H0"/></g></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M6 15.625L15 8 6 .375"/><path stroke-linecap="square" d="M14 8H0"/></g></svg>

--- a/public/assets/icons/arrow-up.svg
+++ b/public/assets/icons/arrow-up.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M15.5 9.852L8 1 .5 9.852"/><path stroke-linecap="square" d="M8 2v14"/></g></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M15.5 9.852L8 1 .5 9.852"/><path stroke-linecap="square" d="M8 2v14"/></g></svg>

--- a/public/assets/icons/close.svg
+++ b/public/assets/icons/close.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M15.266.734L.734 15.266M.734.734l14.532 14.532"/></g></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M15.266.734L.734 15.266M.734.734l14.532 14.532"/></g></svg>

--- a/public/assets/icons/external-link.svg
+++ b/public/assets/icons/external-link.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<g fill="none" fill-rule="evenodd" stroke="currentColor">
+	<g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1">
 		<rect id="frame" stroke="currentColor" x="0.5" y="0.5" width="15" height="15"></rect>
 		<line x1="13.1821591" y1="7.95398449" x2="3.28266415" y2="7.95398449" id="arrow-tail" stroke="currentColor" stroke-linecap="square" transform="translate(8.171751, 8.257538) rotate(-45.000000) translate(-8.171751, -8.257538) "></line>
 		<polyline id="arrow-head" stroke="currentColor" transform="translate(10.000000, 6.000000) scale(-1, 1) rotate(-45.000000) translate(-10.000000, -6.000000) " points="4.34314575 8.82842712 10 3.17157288 15.6568542 8.82842712"></polyline>

--- a/public/assets/icons/index.svg
+++ b/public/assets/icons/index.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M.5.5h6v6h-6zM.5 9.5h6v6h-6zM9.5.5h6v6h-6zM9.5 9.5h6v6h-6z"/></g></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M.5.5h6v6h-6zM.5 9.5h6v6h-6zM9.5.5h6v6h-6zM9.5 9.5h6v6h-6z"/></g></svg>

--- a/public/assets/icons/menu.svg
+++ b/public/assets/icons/menu.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"><path d="M.5 3.5h15M.5 8h8M.5 12.5h12"/></g></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor" stroke-width="1"><path d="M.5 3.5h15M.5 8h8M.5 12.5h12"/></g></svg>

--- a/public/assets/icons/stage.svg
+++ b/public/assets/icons/stage.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" d="M20 1h12M10 11h22M0 21h32M0 31h32M31 32V0M21 32V0M11 32V10M1 32V20"/></svg>
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" stroke-width="2" d="M20 1h12M10 11h22M0 21h32M0 31h32M31 32V0M21 32V0M11 32V10M1 32V20"/></svg>

--- a/src/components/blocks/BlockQuote.astro
+++ b/src/components/blocks/BlockQuote.astro
@@ -24,7 +24,10 @@ const {
 ---
 
 <blockquote class={className}>
-	<Passage {text} />
+	<Passage
+		class="text"
+		{text}
+	/>
 
 	{attribution && (
 		<cite class="type-role-accent type-scale-zeta">
@@ -35,13 +38,13 @@ const {
 
 <style>
 	blockquote {
-		font-style: italic;
 		padding-inline-start: var(--space-medium);
 	}
 
-	blockquote :global(p) {
+	blockquote :global(.text) {
 		font-size: 0.89em;
 		font-style: italic;
+		overflow: visible;
 	}
 
 	cite {

--- a/src/components/blocks/Passage.astro
+++ b/src/components/blocks/Passage.astro
@@ -159,7 +159,6 @@ function htmlSerializer(type, element, content, children): string {
 		font-family: var(--type-font-accent);
 		font-size: var(--type-scale-eta);
 		line-height: var(--size);
-		margin-block-start: 0.25em;
 		margin-inline: 0.35rem;
 		min-height: var(--size);
 		min-width: var(--size);
@@ -167,8 +166,9 @@ function htmlSerializer(type, element, content, children): string {
 		position: relative;
 		text-align: center;
 		text-decoration: none;
-		transform: translateY(10%); /* scoot down a little */
+		transform: translateY(20%); /* scoot down a little */
 		transition: color 0.25s ease, border-color 0.25s ease;
+		vertical-align: top;
 	}
 
 	:global(.sidenote-label):hover,

--- a/src/components/blocks/Passage.astro
+++ b/src/components/blocks/Passage.astro
@@ -77,6 +77,7 @@ function htmlSerializer(type, element, content, children): string {
 }
 ---
 
+<!-- Transitioning to markdown-rendered sidenotes instead of Prismic Rich Text. TODO: phase out the SideNote component. -->
 <script src="@scripts/SideNoteMarkdown.js"></script>
 <script src="@scripts/SideNote.js"></script>
 
@@ -140,6 +141,10 @@ function htmlSerializer(type, element, content, children): string {
 	}
 
 	/* Footnotes/sidenotes */
+	:global([data-supports~='js']) .passage :global(sup) {
+		vertical-align: baseline;
+	}
+
 	:global([data-footnote-ref]),
 	:global(.sidenote-label) {
 		--size: 1.6em;
@@ -154,6 +159,7 @@ function htmlSerializer(type, element, content, children): string {
 		font-family: var(--type-font-accent);
 		font-size: var(--type-scale-eta);
 		line-height: var(--size);
+		margin-block-start: 0.25em;
 		margin-inline: 0.35rem;
 		min-height: var(--size);
 		min-width: var(--size);
@@ -163,13 +169,34 @@ function htmlSerializer(type, element, content, children): string {
 		text-decoration: none;
 		transform: translateY(10%); /* scoot down a little */
 		transition: color 0.25s ease, border-color 0.25s ease;
-		vertical-align: top;
 	}
 
 	:global(.sidenote-label):hover,
 	:global(.sidenote-label):active,
 	:global(.sidenote-label).is-active {
 		--color: var(--color-highlight);
+	}
+
+	:global(.footnotes) {
+		border-radius: var(--border-radius);
+		background-color: var(--color-well);
+		padding: var(--space-medium);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-narrow);
+	}
+
+	:global(.footnotes h2) {
+		font-size: var(--type-scale-delta);
+	}
+
+	:global(.footnotes ol) {
+		margin: 0;
+	}
+
+	:global(.footnotes p),
+	:global(.footnotes ol) {
+		font-size: var(--type-scale-zeta);
 	}
 
 	:global([data-supports~='js'] [data-footnotes]) {

--- a/src/components/elements/Callout.astro
+++ b/src/components/elements/Callout.astro
@@ -36,8 +36,6 @@ const {
 	description,
 	class: className = ''
 } = Astro.props as Props;
-
-console.log(actions)
 ---
 
 <aside class={['callout', className].join(' ')}>

--- a/src/scripts/SideNoteMarkdown.js
+++ b/src/scripts/SideNoteMarkdown.js
@@ -23,6 +23,8 @@ const style = `
 
 			display: inline;
 			font-size: 0; /* eliminate whitespace rendering */
+			vertical-align: top;
+			height: 1rem;
 		}
 
 		.content {
@@ -50,6 +52,47 @@ const style = `
 			position: relative;
 			white-space: nowrap;
 			width: 0;
+			padding: 0;
+		}
+
+		/*
+		 * Needed to repeat this global base type CSS because shadow DOM doesn't inherit.
+		 * - Really don't like this but no other obvious solution presents itself for now
+		 * - Maybe see if I can rework this without using shadow DOM?
+		 * - But then how/where should I handle the wrapper styles below?
+		 */
+		a {
+			--underline-w: 0.125em;
+
+			color: inherit;
+			cursor: pointer;
+			text-decoration-color: var(--color-highlight);
+			text-decoration-style: solid;
+			text-decoration-thickness: var(--underline-w);
+			text-underline-position: under;
+			transition: color 0.25s ease;
+		}
+
+		a:hover,
+		a:active {
+			color: var(--color-highlight);
+		}
+
+		code {
+			background-color: var(--color-island);
+			border-radius: 0.2em;
+			display: inline-block;
+			font-family: "Menlo", "Monaco", "Consolas", "Lucida Console", monospace;
+			font-size: 0.8em;
+			padding: 0 0.25em;
+			color: var(--color-secondary);
+		}
+
+
+		a code {
+			background-color: transparent;
+			border-radius: 0;
+			display: inline;
 			padding: 0;
 		}
 

--- a/src/styles/base/type.css
+++ b/src/styles/base/type.css
@@ -44,7 +44,6 @@
 	font-style: italic;
 	font-weight: 300 600;
 	src:
-		local('Figtree'),
 		url('/assets/fonts/Figtree-Italic.ttf') format('truetype') tech('variations'),
 		url('/assets/fonts/Figtree-Italic.ttf') format('truetype-variations');
 }
@@ -64,7 +63,7 @@
 	font-family: 'Iowan Old Style';
 	font-style: italic;
 	src:
-		local('Iowan Old Style'),
+		local('Iowan Old Style Italic'),
 		url('/assets/fonts/Iowan-Italic.woff2') format('woff2'),
 		url('/assets/fonts/Iowan-Italic.woff') format('woff');
 }
@@ -74,7 +73,7 @@
 	font-family: 'Iowan Old Style';
 	font-weight: bold;
 	src:
-		local('Iowan Old Style'),
+		local('Iowan Old Style Bold'),
 		url('/assets/fonts/Iowan-Bold.woff2') format('woff2'),
 		url('/assets/fonts/Iowan-Bold.woff') format('woff');
 }
@@ -85,7 +84,7 @@
 	font-style: italic;
 	font-weight: bold;
 	src:
-		local('Iowan Old Style'),
+		local('Iowan Old Style Bold Italic'),
 		url('/assets/fonts/Iowan-Bold-Italic.woff2') format('woff2'),
 		url('/assets/fonts/Iowan-Bold-Italic.woff') format('woff');
 }
@@ -187,10 +186,19 @@ em {
 }
 
 code {
-	background-color: var(--color-well);
+	background-color: var(--color-island);
 	border-radius: 0.2em;
 	display: inline-block;
 	font-family: "Menlo", "Monaco", "Consolas", "Lucida Console", monospace;
-	font-size: 0.75em;
+	font-size: 0.8em;
 	padding: 0 0.25em;
+	color: var(--color-secondary);
+}
+
+
+a code {
+	background-color: transparent;
+	border-radius: 0;
+	display: inline;
+	padding: 0;
 }


### PR DESCRIPTION
## Description
- Made some tweaks to type `@font-face` styles so italic and bold variants render correctly
- Tweaked styling on sidenote labels so they (hopefully) align better and don't mess up `line-height`
- Tweaked styling on sidenote content so italics and code render better
- Added explicit stroke widths to SVG icons, in hopes that they render better on small/high-density screens

## Tasks
- [Italic font styles don't show up...](https://app.todoist.com/app/task/icons-rendering-wonky-on-small-screens-6897417770)
- [Icons rendering wonky...](https://app.todoist.com/app/task/icons-rendering-wonky-on-small-screens-6897417770)
