### PR TITLE
Gallery captions and image aspect ratios

### DIFF
--- a/src/components/blocks/Figure.astro
+++ b/src/components/blocks/Figure.astro
@@ -35,7 +35,7 @@ const {
 	caption,
 	device = 'None',
 	class: className,
-	fit = 'default',
+	fit,
 } = Astro.props as Props;
 ---
 

--- a/src/components/blocks/ImageGallery.astro
+++ b/src/components/blocks/ImageGallery.astro
@@ -40,7 +40,7 @@ const {
 
 <Figure
 	class={['image-gallery', className].join(' ')}
-	{caption}
+	caption={caption && { markdown: caption }}
 	{attribution}
 >
 	<Gallery

--- a/src/components/blocks/Passage.astro
+++ b/src/components/blocks/Passage.astro
@@ -79,7 +79,7 @@ function htmlSerializer(type, element, content, children): string {
 
 <!-- Transitioning to markdown-rendered sidenotes instead of Prismic Rich Text. TODO: phase out the SideNote component. -->
 <script src="@scripts/SideNoteMarkdown.js"></script>
-<script src="@scripts/SideNote.js"></script>
+<script src="@scripts/SideNote.ts"></script>
 
 <div class={classList}>
 	<slot>

--- a/src/components/elements/Image.astro
+++ b/src/components/elements/Image.astro
@@ -40,9 +40,12 @@ const { src, srcset } = prismicHelpers.asImageWidthSrcSet(source, {
 	widths,
 });
 const alt = source.alt;
+const sizes = widths.map((width) => `(max-width: ${width}) ${width}px`).join(', ');
 
-const width = widths[0];
-const height = (source.dimensions.height / source.dimensions.width) * widths[0];
+const { width, height } = source.dimensions;
+
+// const width = widths[0];
+// const height = (source.dimensions.height / source.dimensions.width) * widths[0];
 
 const classList = [
 	'image',
@@ -52,7 +55,7 @@ const classList = [
 ].join(' ');
 
 const styleList = arrayToPunctatedString([
-	aspectRatio && `--aspect-ratio: ${aspectRatio}`,
+	`--aspect-ratio: ${aspectRatio || `${width} / ${height}`}`,
 	position && `--object-position: ${position}`,
 	style,
 ]);
@@ -64,19 +67,19 @@ const styleList = arrayToPunctatedString([
 	decoding="async"
 	loading="lazy"
 	{alt}
-	{src}
-	{srcset}
 	{width}
 	{height}
+	{src}
+	{srcset}
+	{sizes}
 />
 
 <style>
 	.image {
-		aspect-ratio: var(--aspect-ratio, auto);
+		aspect-ratio: var(--aspect-ratio);
+		background-color: var(--color-well);
 		content-visibility: auto;
 		display: inline-block;
-		max-width: 100%;
-		object-position: var(--position, 50% 50%);
 	}
 
 	.border {
@@ -85,8 +88,10 @@ const styleList = arrayToPunctatedString([
 
 	.fit,
 	[width][height].fit {
+		background-color: transparent;
 		display: block;
 		height: auto;
+		object-position: var(--position, 50% 50%);
 		width: 100%;
 	}
 

--- a/src/components/elements/Image.astro
+++ b/src/components/elements/Image.astro
@@ -22,6 +22,7 @@ export interface Props {
 	fit?: ImageFit;
 	widths?: Array<number>;
 	position?: string;
+	style?: string;
 }
 
 const {
@@ -41,17 +42,18 @@ const { src, srcset } = prismicHelpers.asImageWidthSrcSet(source, {
 });
 const alt = source.alt;
 const sizes = widths.map((width) => `(max-width: ${width}) ${width}px`).join(', ');
-
 const { width, height } = source.dimensions;
 
-// const width = widths[0];
-// const height = (source.dimensions.height / source.dimensions.width) * widths[0];
+// check the source format and background prop to see if the image has transparency
+// -> use this to turn off the background 'loading' color
+const transparent = source.url.includes('.png') && source?.edit?.background === 'transparent';
 
 const classList = [
 	'image',
 	border ? 'border' : '',
 	className,
 	fit ? `fit ${fit}` : '',
+	transparent ? 'transparent' : '',
 ].join(' ');
 
 const styleList = arrayToPunctatedString([
@@ -80,6 +82,10 @@ const styleList = arrayToPunctatedString([
 		background-color: var(--color-well);
 		content-visibility: auto;
 		display: inline-block;
+	}
+
+	.transparent {
+		background-color: transparent;
 	}
 
 	.border {

--- a/src/components/elements/Image.astro
+++ b/src/components/elements/Image.astro
@@ -55,7 +55,7 @@ const classList = [
 ].join(' ');
 
 const styleList = arrayToPunctatedString([
-	`--aspect-ratio: ${aspectRatio || `${width} / ${height}`}`,
+	`--aspect-ratio: ${aspectRatio || `${width}/${height} auto`}`,
 	position && `--object-position: ${position}`,
 	style,
 ]);

--- a/src/components/elements/PictureFrame.astro
+++ b/src/components/elements/PictureFrame.astro
@@ -30,12 +30,12 @@ export interface Props {
 
 const types = {
 	frame: {
-		matte: 7,
+		matte: 10,
 		border: 0.25,
 	},
 	panel: {
-		matte: 0.2,
-		border: 0.1,
+		matte: 1.5,
+		border: 0.25,
 	},
 };
 
@@ -49,6 +49,14 @@ const {
 	matteColor,
 } = Astro.props as Props;
 
+
+const { width, height } = source.dimensions;
+
+const aspectRatio = [
+	width + ((matteThickness / 100) * width) + (frameThickness * 16),
+	height + ((matteThickness / 100) * width) + (frameThickness * 16),
+].join(' / ');
+
 const classList = [
 	'picture',
 	type,
@@ -58,13 +66,14 @@ const classList = [
 const styleList = arrayToPunctatedString([
 	matteColor && `--matte-color: ${matteColor};`,
 	`--frame-thickness: ${frameThickness}em`,
-	`--matte-thickness: ${matteThickness}vmin`,
+	`--matte-thickness: ${matteThickness}%`,
 ]);
 ---
 
 <Image
 	class={classList}
 	style={styleList}
+	{aspectRatio}
 	{source}
 />
 

--- a/src/components/elements/PictureFrame.astro
+++ b/src/components/elements/PictureFrame.astro
@@ -34,7 +34,7 @@ const types = {
 		border: 0.25,
 	},
 	panel: {
-		matte: 3,
+		matte: 2,
 		border: 0.25,
 	},
 };

--- a/src/components/elements/PictureFrame.astro
+++ b/src/components/elements/PictureFrame.astro
@@ -30,11 +30,11 @@ export interface Props {
 
 const types = {
 	frame: {
-		matte: 10,
+		matte: 20,
 		border: 0.25,
 	},
 	panel: {
-		matte: 1.5,
+		matte: 3,
 		border: 0.25,
 	},
 };
@@ -52,9 +52,11 @@ const {
 
 const { width, height } = source.dimensions;
 
+const matteAndFrameInPx = ((matteThickness / 100) * width) + (frameThickness * 16);
+
 const aspectRatio = [
-	width + ((matteThickness / 100) * width) + (frameThickness * 16),
-	height + ((matteThickness / 100) * width) + (frameThickness * 16),
+	width + matteAndFrameInPx,
+	height + matteAndFrameInPx,
 ].join(' / ');
 
 const classList = [
@@ -64,18 +66,19 @@ const classList = [
 ].filter(i => i).join(' ');
 
 const styleList = arrayToPunctatedString([
+	`--aspect-ratio: ${aspectRatio}`,
 	matteColor && `--matte-color: ${matteColor};`,
 	`--frame-thickness: ${frameThickness}em`,
 	`--matte-thickness: ${matteThickness}%`,
 ]);
 ---
 
-<Image
+<figure
 	class={classList}
 	style={styleList}
-	{aspectRatio}
-	{source}
-/>
+>
+	<Image class="image" {source} />
+</figure>
 
 <style is:global>
 	.picture.frame,
@@ -84,14 +87,24 @@ const styleList = arrayToPunctatedString([
 		--shadow-color: var(--color-shadow);
 		--matte-color: var(--color-island, #fff);
 
+		align-items: center;
+		aspect-ratio: var(--aspect-ratio);
 		background-color: var(--matte-color);
 		border: var(--frame-thickness) solid var(--frame-color);
 		box-shadow: 0 0.25em 0.5em var(--color-shadow);
-		padding: var(--matte-thickness);
+		display: flex;
+		flex-direction: column;
+		height: auto;
+		justify-content: center;
+		margin: 0;
 		max-height: 100%;
 	}
 
 	.picture.panel {
 		box-shadow: 0 0.7em 0.4em var(--color-shadow);
+	}
+
+	.picture .image {
+		width: calc(100% - var(--matte-thickness));
 	}
 </style>

--- a/src/components/layout/Gallery.astro
+++ b/src/components/layout/Gallery.astro
@@ -51,6 +51,7 @@ const classList = [
 		display: grid;
 		gap: var(--gutter);
 		grid-template-columns: 1fr;
+		margin-block: 0;
     padding-inline-start: 0;
     position: relative;
   }

--- a/src/components/navigation/PictureGallery.astro
+++ b/src/components/navigation/PictureGallery.astro
@@ -49,6 +49,7 @@ function matteThickness(picture) {
 	if (columnSize === 'large') return 4;
 	return 3;
 }
+
 ---
 
 <Gallery
@@ -70,7 +71,6 @@ function matteThickness(picture) {
 				href={permalink(picture)}
 			>
 				<PictureFrame
-					matteThickness={matteThickness(picture)}
 					source={picture.data.cover}
 					type={frameType(picture)}
 					{matteColor}

--- a/src/components/navigation/PictureGallery.astro
+++ b/src/components/navigation/PictureGallery.astro
@@ -87,16 +87,13 @@ function matteThickness(picture) {
 
 	.has-aspect .link {
 		flex: 1;
-		align-content: center;
-		align-items: center;
-		display: flex;
-		justify-content: center;
 		max-height: 100%;
 	}
 
-	/* @media screen and (min-width: 40em) {
-		.featured {
-			grid-area: span 2 / span 2;
-		}
-	} */
+	.link > * {
+		position: relative;
+		inset-block-start: 50%;
+		inset-inline-start: 50%;
+		transform: translateX(-50%) translateY(-50%);
+	}
 </style>

--- a/src/pages/pictures/[year]/[month]/[uid].astro
+++ b/src/pages/pictures/[year]/[month]/[uid].astro
@@ -261,6 +261,10 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 	}
 	return result;
 }, []);
+
+const type = substrateName.includes('paper') ? 'frame' : 'panel';
+const matteThickness = type === 'frame' ? 25 : 1;
+const frameThickness = type === 'frame' ? 0.25 : 0.2;
 ---
 
 <Layout
@@ -273,9 +277,11 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 		<!-- cover -->
 		<header class="cover">
 			<PictureFrame
-				source={cover as ImageField}
 				class="cover-image"
-				type={substrateName.includes('paper') ? 'frame' : 'panel'}
+				source={cover as ImageField}
+				{frameThickness}
+				{matteThickness}
+				{type}
 			/>
 			<div class="cover-info | type-scale-epsilon type-role-accent">
 				<Heading level={1} text={title} class="cover-info-item title" />
@@ -336,24 +342,23 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 		grid-template-columns: var(--space-outside) 1fr var(--space-outside);
 		/* add a space above the top margin roughly the height of the main nav
 				to keep the cover image vertically centered */
-		grid-template-rows: 3.125rem var(--space-xwide) minmax(60dvh, 1fr) auto var(--space-wide);
+		grid-template-rows: var(--space-xwide) minmax(60svh, 1fr) auto var(--space-xwide);
 		grid-template-areas:
-			'nav-space nav-space nav-space'
 			'. . .'
 			'. image .'
 			'. info .'
 			'. . .';
-		height: 100vh;
-		height: 100svh;
+		height: calc(100svh - 3.4rem);
 		position: relative;
-		justify-content: center;
-		align-items: center;
 	}
 
 	.cover :global(.cover-image) {
 		grid-area: image;
 		max-height: 100%;
-		margin-inline: auto;
+		position: relative;
+		inset-block-start: 50%;
+		inset-inline-start: 50%;
+		transform: translateX(-50%) translateY(-50%);
 	}
 
 	.cover-info {
@@ -366,7 +371,7 @@ const editionsByType: EditionsByPrintType[] = editions.reduce((result, edition) 
 		gap: var(--gap);
 		grid-area: info;
 		justify-content: center;
-		padding-block-start: var(--space-xwide);
+		padding-block-start: var(--space-wide);
 	}
 
 	.cover :global(.cover-info-item) {


### PR DESCRIPTION
## Description
- Fixed a bug on the 'caption' prop of the `ImageGallery` component, where the text object wasn't formatted right
- Set explicit aspect ratios on all images, so that they take up the correct space in the layout while loading (rather than causing CLS)
- Fixed the same issue in the `PictureFrame` component, where the frame would be 'collapsed' until the image it contains loads

## Tasks
- [Images are causing layout shifts...](https://app.todoist.com/app/task/images-are-at-0x0px-until-they-load-causing-annoying-layout-shifts-6V4Crwm8jf8VXXPw)
- [Captions not showing up...](https://app.todoist.com/app/task/captions-not-showing-up-on-image-gallery-blocks-6VWpqMPph5xhhc9w)
