### PR TITLE
Fix image frame distortion

### DIFF
--- a/public/assets/icons/arrow-down.svg
+++ b/public/assets/icons/arrow-down.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M.5 6L8 14.852 15.5 6"/><path stroke-linecap="square" d="M8 .5V14"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M.5 6L8 14.852 15.5 6"/><path stroke-linecap="square" d="M8 .5V14"/></g></svg>

--- a/public/assets/icons/arrow-left.svg
+++ b/public/assets/icons/arrow-left.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M9.875 15.625L.875 8l9-7.625"/><path stroke-linecap="square" d="M15.5 8h-14"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M9.875 15.625L.875 8l9-7.625"/><path stroke-linecap="square" d="M15.5 8h-14"/></g></svg>

--- a/public/assets/icons/arrow-right.svg
+++ b/public/assets/icons/arrow-right.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M6 15.625L15 8 6 .375"/><path stroke-linecap="square" d="M14 8H0"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M6 15.625L15 8 6 .375"/><path stroke-linecap="square" d="M14 8H0"/></g></svg>

--- a/public/assets/icons/arrow-up.svg
+++ b/public/assets/icons/arrow-up.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M15.5 9.852L8 1 .5 9.852"/><path stroke-linecap="square" d="M8 2v14"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M15.5 9.852L8 1 .5 9.852"/><path stroke-linecap="square" d="M8 2v14"/></g></svg>

--- a/public/assets/icons/close.svg
+++ b/public/assets/icons/close.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M15.266.734L.734 15.266M.734.734l14.532 14.532"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M15.266.734L.734 15.266M.734.734l14.532 14.532"/></g></svg>

--- a/public/assets/icons/external-link.svg
+++ b/public/assets/icons/external-link.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg">
 	<g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1">
 		<rect id="frame" stroke="currentColor" x="0.5" y="0.5" width="15" height="15"></rect>
 		<line x1="13.1821591" y1="7.95398449" x2="3.28266415" y2="7.95398449" id="arrow-tail" stroke="currentColor" stroke-linecap="square" transform="translate(8.171751, 8.257538) rotate(-45.000000) translate(-8.171751, -8.257538) "></line>

--- a/public/assets/icons/index.svg
+++ b/public/assets/icons/index.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M.5.5h6v6h-6zM.5 9.5h6v6h-6zM9.5.5h6v6h-6zM9.5 9.5h6v6h-6z"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="1"><path d="M.5.5h6v6h-6zM.5 9.5h6v6h-6zM9.5.5h6v6h-6zM9.5 9.5h6v6h-6z"/></g></svg>

--- a/public/assets/icons/menu.svg
+++ b/public/assets/icons/menu.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor" stroke-width="1"><path d="M.5 3.5h15M.5 8h8M.5 12.5h12"/></g></svg>
+<svg viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor" stroke-width="1"><path d="M.5 3.5h15M.5 8h8M.5 12.5h12"/></g></svg>

--- a/public/assets/icons/stage.svg
+++ b/public/assets/icons/stage.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" stroke-width="2" d="M20 1h12M10 11h22M0 21h32M0 31h32M31 32V0M21 32V0M11 32V10M1 32V20"/></svg>
+<svg viewBox="0 0 32 32" width="32" height="32" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" stroke-width="2" d="M20 1h12M10 11h22M0 21h32M0 31h32M31 32V0M21 32V0M11 32V10M1 32V20"/></svg>

--- a/src/components/blocks/Billboard.astro
+++ b/src/components/blocks/Billboard.astro
@@ -97,6 +97,7 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 		: <Figure
 				class="cover"
 				fit="contain"
+				maxHeight="80"
 				{...images[0]}
 			/>
 	}

--- a/src/components/blocks/Billboard.astro
+++ b/src/components/blocks/Billboard.astro
@@ -128,7 +128,7 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 		padding-block: var(--space-xwide);
 	}
 
-	.billboard :global(.cover) {
+	.billboard > :global(.cover) {
 		justify-self: center;
 		align-self: center;
 		width: 100%;

--- a/src/components/blocks/Billboard.astro
+++ b/src/components/blocks/Billboard.astro
@@ -130,11 +130,8 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 
 	.billboard :global(.cover) {
 		justify-self: center;
+		align-self: center;
 		width: 100%;
-	}
-
-	.billboard :global(.cover img) {
-		max-height: 60vh;
 	}
 
 	@media screen and (min-width: 42em) {

--- a/src/components/blocks/Collage.astro
+++ b/src/components/blocks/Collage.astro
@@ -101,6 +101,14 @@ function getItemClassList(
 		}
 	}
 
+	li {
+		display: inline-block;
+	}
+
+	li > :global(*) {
+		margin-inline: auto;
+	}
+
 	li + li {
 		margin-top: 0;
 	}
@@ -117,7 +125,7 @@ function getItemClassList(
 
 	@media screen and (min-width: 40em) {
 		.priority-2 {
-			display: block;
+			display: inline-block;
 		}
 
 		.wide {
@@ -131,7 +139,7 @@ function getItemClassList(
 
 	@media screen and (min-width: 64em) {
 		.priority-3 {
-			display: block;
+			display: inline-block;
 		}
 	}
 </style>

--- a/src/components/blocks/Figure.astro
+++ b/src/components/blocks/Figure.astro
@@ -65,11 +65,9 @@ const {
 
 <style>
 	.figure {
-		text-align: center;
-	}
+		--max-height: 80;
 
-	.figure :global(img) {
-		width: 100%;
+		text-align: center;
 	}
 
 	.figure :global(.caption) {

--- a/src/components/blocks/Figure.astro
+++ b/src/components/blocks/Figure.astro
@@ -22,10 +22,11 @@ export interface Props {
 	attribution?: FormattedText;
 	border?: boolean;
 	caption?: FormattedText;
-	frame?: Frame;
+	class?: string;
 	device?: Frame;
 	fit?: ImageFit;
-	class?: string;
+	frame?: Frame;
+	maxHeight?: number;
 }
 
 // props
@@ -37,11 +38,12 @@ const {
 	frame = 'None',
 	class: className,
 	fit,
+	maxHeight,
 } = Astro.props as Props;
 ---
 
 <figure class={['figure', className].join(' ')}>
-	<RevealOnScroll>
+	<RevealOnScroll class="wrapper">
 		<slot>
 			{source && (
 				<ImageFrame
@@ -49,6 +51,7 @@ const {
 					{fit}
 					{frame}
 					{source}
+					{maxHeight}
 				/>
 			)}
 		</slot>
@@ -64,9 +67,8 @@ const {
 </figure>
 
 <style>
-	.figure {
-		--max-height: 80;
-
+	.figure,
+	.figure :global(.wrapper) {
 		text-align: center;
 	}
 

--- a/src/components/elements/Image.astro
+++ b/src/components/elements/Image.astro
@@ -95,7 +95,6 @@ const styleList = arrayToPunctatedString([
 	.fit,
 	[width][height].fit {
 		background-color: transparent;
-		height: auto;
 		object-position: var(--object-position, center);
 		width: 100%;
 	}

--- a/src/components/elements/Image.astro
+++ b/src/components/elements/Image.astro
@@ -20,9 +20,10 @@ export interface Props {
 	border?: boolean;
 	class?: string;
 	fit?: ImageFit;
-	widths?: Array<number>;
+	maxHeight?: number;
 	position?: string;
 	style?: string;
+	widths?: Array<number>;
 }
 
 const {
@@ -31,9 +32,10 @@ const {
 	border = false,
 	class: className = '',
 	fit,
+	maxHeight,
 	position,
-	widths = [ 800, 1200, 2000 ],
 	style,
+	widths = [ 800, 1200, 2000 ],
 } = Astro.props as Props;
 
 const { src, srcset } = prismicHelpers.asImageWidthSrcSet(source, {
@@ -53,12 +55,14 @@ const classList = [
 	border ? 'border' : '',
 	className,
 	fit ? `fit ${fit}` : '',
+	maxHeight ? 'limit-height' : '',
 	transparent ? 'transparent' : '',
 ].join(' ');
 
 const styleList = arrayToPunctatedString([
-	`--aspect-ratio: ${aspectRatio || `${width}/${height} auto`}`,
-	position && `--object-position: ${position}`,
+	`--aspect-ratio: ${aspectRatio || `${width}/${height}`};`,
+	maxHeight ? `--max-height: ${maxHeight};` : '',
+	position ? `--object-position: ${position};` : '',
 	style,
 ]);
 ---
@@ -84,6 +88,12 @@ const styleList = arrayToPunctatedString([
 		display: inline-block;
 	}
 
+	.limit-height {
+		max-width: 100%;
+		max-height: calc(var(--max-height) * 1vh);
+		max-height: calc(var(--max-height) * 1svh);
+	}
+
 	.transparent {
 		background-color: transparent;
 	}
@@ -96,7 +106,6 @@ const styleList = arrayToPunctatedString([
 	[width][height].fit {
 		background-color: transparent;
 		object-position: var(--object-position, center);
-		width: 100%;
 	}
 
 	.fit.contain {

--- a/src/components/elements/Image.astro
+++ b/src/components/elements/Image.astro
@@ -95,9 +95,8 @@ const styleList = arrayToPunctatedString([
 	.fit,
 	[width][height].fit {
 		background-color: transparent;
-		display: block;
 		height: auto;
-		object-position: var(--position, 50% 50%);
+		object-position: var(--object-position, center);
 		width: 100%;
 	}
 

--- a/src/components/elements/ImageFrame.astro
+++ b/src/components/elements/ImageFrame.astro
@@ -13,6 +13,7 @@ export interface Props {
 	border?: boolean;
 	fit?: ImageFit;
 	frame?: Frame;
+	maxHeight?: number;
 }
 
 const {
@@ -20,6 +21,7 @@ const {
 	border,
 	fit,
 	frame,
+	maxHeight,
 } = Astro.props as Props;
 
 const imageComponents = {
@@ -28,6 +30,7 @@ const imageComponents = {
 		props: {
 			border,
 			fit,
+			maxHeight,
 			source,
 		},
 	},
@@ -35,6 +38,7 @@ const imageComponents = {
 		component: ImageFrameWall,
 		props: {
 			type: 'matte',
+			maxHeight,
 			source,
 		},
 	},
@@ -42,6 +46,7 @@ const imageComponents = {
 		component: ImageFrameWall,
 		props: {
 			type: 'frame',
+			maxHeight,
 			source,
 		},
 	},
@@ -49,6 +54,7 @@ const imageComponents = {
 		component: ImageFrameWall,
 		props: {
 			type: 'panel',
+			maxHeight,
 			source,
 		},
 	},
@@ -56,6 +62,7 @@ const imageComponents = {
 		component: ImageFrameDevice,
 		props: {
 			type: 'Phone',
+			maxHeight,
 			source,
 		},
 	},
@@ -63,6 +70,7 @@ const imageComponents = {
 		component: ImageFrameDevice,
 		props: {
 			type: 'Tablet (landscape)',
+			maxHeight,
 			source,
 		},
 	},
@@ -70,6 +78,7 @@ const imageComponents = {
 		component: ImageFrameDevice,
 		props: {
 			type: 'Tablet (portrait)',
+			maxHeight,
 			source,
 		},
 	},

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -102,7 +102,7 @@
 		}
 
 		.device-frame.phone {
-			--aspect-ratio: 1/2;
+			--aspect-ratio: 1/2.05;
 			--bezel-radius: 10% / 5%;
 			--bezel-width-x: 3.5%;
 			--bezel-width-y: 11%;

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -83,7 +83,7 @@ function calculateOuterAspectRatio(source) {
 			background-color: var(--color-bg);
 			border-radius: var(--bezel-radius);
 			border: 1px solid var(--color-border);
-			box-shadow: var(--elevation-medium);
+			box-shadow: 0 0.125em 0.25em var(--color-shadow);
 			display: flex;
 			max-height: calc(var(--max-height) * 1vh);
 			max-height: calc(var(--max-height) * 1svh);
@@ -124,8 +124,6 @@ function calculateOuterAspectRatio(source) {
 			--bezel-width-x: 3.5%;
 			--bezel-width-y: 11%;
 			--screen-radius: 2% / 1%;
-
-			box-shadow: var(--elevation-low);
 		}
 	}
 </style>

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -27,25 +27,16 @@
 	} = Astro.props as Props;
 
 	const types = {
-		'Phone': {
-			className: 'phone',
-			ratio: '1/2',
-		},
-		'Tablet (landscape)': {
-			className: 'tablet-landscape',
-			ratio: '4/3',
-		},
-		'Tablet (portrait)': {
-			className: 'tablet-portrait',
-			ratio: '3/4',
-		},
+		'Phone': 'phone',
+		'Tablet (landscape)': 'tablet-landscape',
+		'Tablet (portrait)': 'tablet-portrait',
 	};
 
 	const El = el;
 
 	const classList = [
 		'device-frame',
-		types[type]?.className || '',
+		types[type] || '',
 		className,
 	].join(' ');
 ---
@@ -71,21 +62,24 @@
 			--bezel-width-y: 5%;
 			--screen-radius:  0.75% / 1%;
 
+			aspect-ratio: var(--aspect-ratio);
 			background-color: var(--color-bg);
 			border-radius: var(--bezel-radius);
 			border: 1px solid var(--color-border);
-			display: block;
-			overflow: hidden;
-			position: relative;
-			padding: var(--bezel-width-y) var(--bezel-width-x);
 			box-shadow: var(--elevation-medium);
+			display: flex;
+			max-height: 60vh;
+			max-height: 60svh;
+			max-width: 100%;
+			overflow: hidden;
+			padding: var(--bezel-width-y) var(--bezel-width-x);
+			position: relative;
 		}
 
 		.wrapper {
 			/* set the inner aspect ratio and crop the image
 			 * - Firefox bug distorts the image if we use object-fit and position here
 			*/
-			aspect-ratio: var(--aspect-ratio);
 			border-radius: var(--screen-radius);
 			border: 1px solid var(--color-border);
 			overflow: hidden;

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -1,47 +1,64 @@
 ---
-	// Add a frame around content that looks like a mobile device
-	// -> Phone, Tablet (horizontal and vertical)
+// Add a frame around content that looks like a mobile device
+// -> Phone, Tablet (horizontal and vertical)
 
-	// assets
-	import '@styles/tokens/color.css';
+// assets
+import '@styles/tokens/color.css';
 
-	// components
-	import Image from '@components/elements/Image.astro';
+// components
+import Image from '@components/elements/Image.astro';
 
-	// types
-	import type { Frame } from '@lib/types';
-	import type { ImageField } from '@prismicio/types';
+// types
+import type { Frame } from '@lib/types';
+import type { ImageField } from '@prismicio/types';
 
-	export interface Props {
-		source: ImageField,
-		class?: string,
-		el?: string,
-		type?: Frame,
-	};
+export interface Props {
+	source: ImageField;
+	useImageAspectRatio?: boolean;
+	class?: string;
+	el?: string;
+	maxHeight?: number;
+	type?: Frame;
+};
 
-	const {
-		source,
-		el = 'div',
-		class: className = '',
-		type = 'Tablet (landscape)',
-	} = Astro.props as Props;
+const {
+	source,
+	useImageAspectRatio = false,
+	class: className = '',
+	el = 'div',
+	maxHeight = 75,
+	type = 'Tablet (landscape)',
+} = Astro.props as Props;
 
-	const types = {
-		'Phone': 'phone',
-		'Tablet (landscape)': 'tablet-landscape',
-		'Tablet (portrait)': 'tablet-portrait',
-	};
+const types = {
+	'Phone': 'phone',
+	'Tablet (landscape)': 'tablet-landscape',
+	'Tablet (portrait)': 'tablet-portrait',
+};
 
-	const El = el;
+const El = el;
 
-	const classList = [
-		'device-frame',
-		types[type] || '',
-		className,
-	].join(' ');
+const classList = [
+	'device-frame',
+	types[type] || '',
+	className,
+].join(' ');
+
+function calculateOuterAspectRatio(source) {
+	const { width, height } = source.dimensions;
+	const autoAspectX = width + (width * 0.035);
+	const autoAspectY = height + (width * 0.11) + 16;
+	return `${autoAspectX} / ${autoAspectY}`;
+}
 ---
 
-<El class={classList}>
+<El
+	class={classList}
+	style={[
+		maxHeight ? `--max-height: ${maxHeight};` : '',
+		useImageAspectRatio ? `--aspect-ratio: ${calculateOuterAspectRatio(source)};` : '',
+	].join(' ')}
+>
 	<div class="wrapper">
 		<Image {source} />
 	</div>
@@ -68,8 +85,8 @@
 			border: 1px solid var(--color-border);
 			box-shadow: var(--elevation-medium);
 			display: flex;
-			max-height: 60vh;
-			max-height: 60svh;
+			max-height: calc(var(--max-height) * 1vh);
+			max-height: calc(var(--max-height) * 1svh);
 			max-width: 100%;
 			overflow: hidden;
 			padding: var(--bezel-width-y) var(--bezel-width-x);

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -15,11 +15,13 @@
 	export interface Props {
 		source: ImageField,
 		class?: string,
+		el?: string,
 		type?: Frame,
 	};
 
 	const {
 		source,
+		el = 'div',
 		class: className = '',
 		type = 'Tablet (landscape)',
 	} = Astro.props as Props;
@@ -39,6 +41,8 @@
 		},
 	};
 
+	const El = el;
+
 	const classList = [
 		'device-frame',
 		types[type]?.className || '',
@@ -46,14 +50,11 @@
 	].join(' ');
 ---
 
-<div class={classList}>
-	<Image
-		aspectRatio={types[type]?.ratio}
-		fit="cover"
-		position="y-start center"
-		{source}
-	/>
-</div>
+<El class={classList}>
+	<div class="wrapper">
+		<Image {source} />
+	</div>
+</El>
 
 <style>
 	/*
@@ -64,6 +65,7 @@
 	@supports (aspect-ratio: 1/2) {
 		.device-frame {
 			/* use percentage units for the bezel and corners, so they scale fluidly with the image and aspect ratio */
+			--aspect-ratio: 4/3;
 			--bezel-radius: 4.5% / 6%;
 			--bezel-width-x: 5%;
 			--bezel-width-y: 5%;
@@ -76,7 +78,17 @@
 			overflow: hidden;
 			position: relative;
 			padding: var(--bezel-width-y) var(--bezel-width-x);
-			box-shadow: 0 0.125em 0.25em var(--color-shadow);
+			box-shadow: var(--elevation-medium);
+		}
+
+		.wrapper {
+			/* set the inner aspect ratio and crop the image
+			 * - Firefox bug distorts the image if we use object-fit and position here
+			*/
+			aspect-ratio: var(--aspect-ratio);
+			border-radius: var(--screen-radius);
+			border: 1px solid var(--color-border);
+			overflow: hidden;
 		}
 
 		@media screen and (min-width: 40em) {
@@ -85,26 +97,24 @@
 			}
 		}
 
-		.device-frame :global(img) {
-			border-radius: var(--screen-radius);
-			border: 1px solid var(--color-border);
-			object-fit: cover;
-			object-position: top center;
+		.device-frame.tablet-landscape {
+			--aspect-ratio: 4/3;
+			--screen-radius: 1%;
 		}
 
 		.device-frame.tablet-portrait {
-			--bezel-radius: 6% / 4.5%;
-		}
-
-		.device-frame.tablet-portrait {
-			--screen-radius: 1% / 0.75%;
+			--aspect-ratio: 3/4;
+			--bezel-radius: 6%;
 		}
 
 		.device-frame.phone {
+			--aspect-ratio: 1/2;
 			--bezel-radius: 10% / 5%;
 			--bezel-width-x: 3.5%;
 			--bezel-width-y: 11%;
 			--screen-radius: 2% / 1%;
+
+			box-shadow: var(--elevation-low);
 		}
 	}
 </style>

--- a/src/components/elements/ImageFrameWall.astro
+++ b/src/components/elements/ImageFrameWall.astro
@@ -19,13 +19,14 @@ import type {
 } from '@lib/types';
 
 export interface Props {
-	source: ImageField,
-	class?: string,
-	el?: string,
-	frameThickness: number,
-	matteColor?: CSSVariable | HexColor | HSLColor | HSLAColor,
-	matteThickness?: number,
-	type?: 'matte' | 'frame' | 'panel',
+	source: ImageField;
+	class?: string;
+	el?: string;
+	frameThickness: number;
+	matteColor?: CSSVariable | HexColor | HSLColor | HSLAColor;
+	matteThickness?: number;
+	maxHeight: number;
+	type?: 'matte' | 'frame' | 'panel';
 };
 
 const types = {
@@ -56,6 +57,7 @@ const {
 	frameThickness = types[type].border,
 	matteThickness = types[type].matte,
 	matteColor,
+	maxHeight,
 	el = 'figure',
 } = Astro.props as Props;
 
@@ -89,7 +91,11 @@ const styleList = arrayToPunctatedString([
 	class={classList}
 	style={styleList}
 >
-	<Image class="image" {source} />
+	<Image
+		class="image"
+		{source}
+		{maxHeight}
+	/>
 </El>
 
 <style is:global>

--- a/src/components/layout/DataGrid.astro
+++ b/src/components/layout/DataGrid.astro
@@ -14,6 +14,7 @@ import { SpaceScale, TypeScale } from '@lib/types';
 export type DataItem = {
 	label: string,
 	value: string[] | string,
+	html?: boolean,
 };
 
 export interface Props {
@@ -51,13 +52,19 @@ const itemClassList = [
 				<span class={itemClassList}>{item.label}</span>
 			</dt>
 			{Array.isArray(item.value)
-				? item.value.map((valueItem) => (
+				? item.value.map((seriesItem) => (
 						<dd class={['item', item.value.length > 1 && 'series'].join(' ')}>
-							<span class={itemClassList}>{valueItem}</span>
+							{item.html
+							? <span class={itemClassList} set:html={seriesItem} />
+							: <span class={itemClassList}>{seriesItem}</span>
+						}
 						</dd>
 					))
 				: <dd class="item">
-						<span class={itemClassList}>{item.value}</span>
+						{item.html
+							? <span class={itemClassList} set:html={item.value} />
+							: <span class={itemClassList}>{item.value}</span>
+						}
 					</dd>
 				}
 		</div>
@@ -69,6 +76,10 @@ const itemClassList = [
 	  list-style: none;
 	  display: grid;
 		gap: var(--gutter);
+	}
+
+	.group {
+		line-height: var(--type-leading-tight);
 	}
 
 	.item {
@@ -84,9 +95,10 @@ const itemClassList = [
 	/* trick from https://codepen.io/ShadowShahriar/pen/LYyvVjo */
 	.item.series {
 		--separator: ',';
+
 		display: inline;
-		padding: 0;
 		margin: 0;
+		padding: 0;
 	}
 
 	.item.series > span::after {

--- a/src/components/navigation/MainFooter.astro
+++ b/src/components/navigation/MainFooter.astro
@@ -277,32 +277,27 @@ socialChannelList.join('');
 	}
 
 	footer :global(.about-portrait) {
-		--size: 6rem;
-
 		aspect-ratio: 1.2 / 1;
 		border-radius: var(--border-radius);
 		object-fit: cover;
-		width: var(--size);
 	}
 
 	@container about (min-width: 24em) {
 		.about-wrapper {
+		--portrait-width: 6rem;
+
 			display: grid;
 			gap: var(--space-medium);
-			grid-template-columns: auto 1fr;
+			grid-template-columns: var(--portrait-width) 1fr;
 			grid-template-rows: auto;
 			grid-template-areas:
 				'portrait blurb';
 		}
-
-		footer :global(.about-portrait) {
-			--size: 8rem;
-		}
 	}
 
 	@container about (min-width: 34em) {
-		footer :global(.about-portrait) {
-			--size: 12rem;
+		.about-wrapper {
+			--portrait-width: 12rem;
 		}
 	}
 

--- a/src/components/navigation/MainNav.astro
+++ b/src/components/navigation/MainNav.astro
@@ -126,7 +126,7 @@ const classList = [
 					id="nav-button"
 				>
 					<span>Menu</span>
-					<svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+					<svg class="icon" viewBox="0 0 16 16" width="32" height="32" xmlns="http://www.w3.org/2000/svg">
 						<path class="open" d="M.5 3.5h15M.5 8h8M.5 12.5h12" fill="none" fill-rule="evenodd" stroke-linecap="square" stroke="currentColor"/>
 						<path class="close" d="M15.266.734L.734 15.266M.734.734l14.532 14.532" fill="none" fill-rule="evenodd" stroke="currentColor"/>
 					</svg>

--- a/src/pages/blog/[year]/[month]/[day]/[uid].astro
+++ b/src/pages/blog/[year]/[month]/[day]/[uid].astro
@@ -294,15 +294,16 @@ const {
 		margin-block-start: var(--space-wide);
 	}
 
-	article :global(.tags) {
+	main :global(.tags) {
 		display: flex;
 		align-items: baseline;
 		gap: 0.25em;
 		flex-wrap: wrap;
+		padding-block-end: var(--space-wide);
 	}
 
 	@media screen and (min-width: 30em) {
-		article :global(.tags) {
+		main :global(.tags) {
 			gap: var(--space-xnarrow);
 			flex-wrap: nowrap;
 		}

--- a/src/pages/design/[year]/[uid].astro
+++ b/src/pages/design/[year]/[uid].astro
@@ -2,7 +2,7 @@
 // assets
 import '@styles/tokens/spacing.css';
 import '@styles/tokens/contentWidth.css';
-import '@styles/utilities/borders.css';
+import '@styles/tokens/borders.css';
 
 // components
 import Layout from '@layouts/BaseLayout.astro';
@@ -34,6 +34,11 @@ export type Contribution = {
 	task: string,
 };
 
+export type Collaborator = {
+	name: string,
+	website: string,
+};
+
 export interface Props {
 	agency: string;
 	body: Slice[];
@@ -41,7 +46,7 @@ export interface Props {
 	role: string;
 	startDate: NumberField;
 	title: TitleField;
-	collaborators?: RelationField[];
+	collaborators?: Collaborator[];
 	contributions?: GroupField;
 	endDate?: NumberField;
 	next?: PaginationLink;
@@ -63,6 +68,7 @@ export async function getStaticPaths() {
 						collaborator {
 							...on collaborator {
 								name
+								website
 							}
 						}
 					}
@@ -96,7 +102,7 @@ export async function getStaticPaths() {
 					title: data.seo_title || prismicHelpers.asText(data.title),
 				},
 				collaborators: collaborators.map(
-					({ collaborator }) => collaborator.data.name
+					({ collaborator }) => collaborator.data
 				),
 				next: nextPost && {
 					title: nextPost.data.title,
@@ -146,7 +152,11 @@ const credits = [
 	{
 		label: 'Collaborators',
 		// need to resolve these links
-		value: collaborators,
+		value: collaborators.map(({ name, website }) => {
+			if (website) return `<a href="${website}" target="_blank">${name}</a>`;
+			return name;
+		}),
+		html: true,
 	},
 ];
 ---
@@ -168,7 +178,7 @@ const credits = [
 
 			<BlockList {body} showLedeStyle />
 
-			<aside class="border-seam-top credits">
+			<aside class="credits">
 				<div class="credits-wrapper">
 					<Heading
 						level={2}
@@ -178,7 +188,7 @@ const credits = [
 					</Heading>
 					<DataGrid
 						data={credits}
-						columnWidth={16}
+						columnWidth={20}
 						gutter="wide"
 					/>
 				</div>
@@ -219,8 +229,9 @@ const credits = [
 	}
 
 	.credits {
-		padding: var(--space-xwide) var(--space-outside);
+		border-block-start: var(--border-default);
 		margin-block-start: var(--space-xwide);
+		padding: var(--space-xwide) var(--space-outside);
 	}
 
 	.credits :global(.credits-heading) {


### PR DESCRIPTION
## Description
- Reworked CSS around image `aspect-ratio` and dimension properties to avoid distortion in different screen size contexts
- Set up props to handle maximum heights (e.g. 80vh) more gracefully, also without distortion
- Fix smaller bugs: links in design credits for collaborators, spacing in tag list in blog posts, and distortion in the footer portrait

## Tasks
- [Screenshots getting distorted](https://app.todoist.com/app/task/screenshots-getting-distorted-in-the-device-frame-component-6VcFXC6w2jvc36QP)
- [Spacing bug in the 'filed under'...](https://app.todoist.com/app/task/spacing-bug-in-the-filed-under-nav-on-blog-posts-i-pad-os-safari-6X2xpgrfXh8Qj89w)
