### PR TITLE
Device frame with auto aspect ratios (derived from the image dimensions)

### DIFF
--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -93,6 +93,7 @@ function billboard(slice: Slice): BlockType {
 			relative_size: relativeSize,
 			cover_image: source,
 			dark_mode_cover_image: darkModeSource,
+			use_image_aspect_ratio: useImageAspectRatio = false,
 		} = item;
 
 		if ((source as ImageField).url === '') return result;
@@ -103,6 +104,7 @@ function billboard(slice: Slice): BlockType {
 			relativeSize,
 			source,
 			darkModeSource,
+			useImageAspectRatio,
 		});
 		return result;
 	}, []);
@@ -154,6 +156,7 @@ function collage(slice: Slice): BlockType {
 			priority = '1',
 			relative_size: relativeSize,
 			image: source,
+			use_image_aspect_ratio: useImageAspectRatio = false,
 		} = item;
 
 		return {
@@ -161,6 +164,7 @@ function collage(slice: Slice): BlockType {
 			priority,
 			relativeSize,
 			source,
+			useImageAspectRatio,
 		};
 	});
 
@@ -207,6 +211,7 @@ function figure(slice: Slice): BlockType {
 		image_dark_mode,
 		border = false,
 		frame = 'None',
+		use_image_aspect_ratio = false,
 	} = slice.primary;
 
 	const output = {
@@ -216,6 +221,7 @@ function figure(slice: Slice): BlockType {
 		darkModeSource: image_dark_mode,
 		attribution: undefined,
 		caption: undefined,
+		useImageAspectRatio: use_image_aspect_ratio,
 		...sharedBlockFields(slice),
 	};
 
@@ -254,6 +260,7 @@ function imageGallery(slice: Slice): BlockType {
 		column_size: columnSize,
 		gutter,
 		frame = 'None',
+		use_image_aspect_ratio: useImageAspectRatio = false,
 	} = slice.primary;
 
 	return {
@@ -266,6 +273,7 @@ function imageGallery(slice: Slice): BlockType {
 			image: item.image,
 			darkModeImage: item.dark_mode_image,
 		})),
+		useImageAspectRatio,
 		...sharedBlockFields(slice),
 	};
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -44,6 +44,7 @@ export interface CollageItem {
 	frame?: Frame;
 	priority?: CollageItemPriority;
 	relativeSize?: CollageItemSize;
+	useImageAspectRatio?: boolean;
 }
 
 // --- type ---

--- a/src/components/blocks/Billboard.astro
+++ b/src/components/blocks/Billboard.astro
@@ -1,7 +1,4 @@
 ---
-import type { CollageItem } from '@lib/types';
-import type { RichTextField, LinkField } from '@prismicio/types';
-
 /**
  * Billboard block component
  * - A teaser that displays a blurb and cover image, links to other content
@@ -17,25 +14,27 @@ import type { RichTextField, LinkField } from '@prismicio/types';
  * @param {string} [subtitle] - subtitle to display below the title
  */
 
-// assets
+// --- assets ---
 import '@styles/tokens/spacing.css';
 import '@styles/tokens/type.css';
 import arrowRight from '@icons/arrow-right.svg?raw';
 
-// utils
+// --- utils ---
 import { linkResolver } from '@lib/routes';
 import * as prismicHelpers from '@prismicio/helpers';
 
-// components
+// --- components ---
 import Button from '@components/elements/Button.astro';
 import Figure from '@components/blocks/Figure.astro';
 import Collage from '@components/blocks/Collage.astro';
 import Heading from '@components/blocks/Heading.astro';
 import Passage from '@components/blocks/Passage.astro';
 
-// types
-import { removeWidows } from '@lib/stringHelpers';
+// --- types ---
+import type { CollageItem } from '@lib/types';
+import type { RichTextField, LinkField } from '@prismicio/types';
 
+// --- props ---
 const {
 	images,
 	cta,
@@ -54,22 +53,22 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 			<a
 				class="type-link-undecorated"
 				href={resolvedLink}
-				set:html={removeWidows(title)}
 			>
+				{title}
 			</a>
 		</Heading>
 
 		{subtitle && (
 			<Heading
-			class="subtitle"
-			level={3}
-			subheading
+				class="subtitle"
+				level={3}
+				subheading
 			>
 				<a
 					class="type-link-undecorated"
 					href={resolvedLink}
-					set:html={removeWidows(subtitle)}
 				>
+					{subtitle}
 				</a>
 			</Heading>
 		)}
@@ -137,7 +136,7 @@ const resolvedLink = link && prismicHelpers.asLink(link, linkResolver);
 
 	@media screen and (min-width: 42em) {
 		.billboard {
-			grid-template-columns: repeat(auto-fit, minmax(35rem, 1fr));
+			grid-template-columns: repeat(auto-fit, minmax(38rem, 1fr));
 			gap: var(--space-wide);
 		}
 	}

--- a/src/components/blocks/Collage.astro
+++ b/src/components/blocks/Collage.astro
@@ -72,7 +72,14 @@ function getItemClassList(relativeSize, priority = '1') {
 		class="collage"
 		style={`--gutter: var(--space-${gutter});`}
 	>
-		{images.map(({ source, darkModeSource, relativeSize, frame, priority }) => (
+		{images.map(({
+			source,
+			darkModeSource,
+			relativeSize,
+			frame,
+			priority,
+			useImageAspectRatio,
+		}) => (
 			<li class={getItemClassList(relativeSize, priority)}>
 				<ImageFrame
 					fit={fitImages}
@@ -80,6 +87,7 @@ function getItemClassList(relativeSize, priority = '1') {
 					{darkModeSource}
 					{border}
 					{frame}
+					{useImageAspectRatio}
 				/>
 			</li>
 		))}

--- a/src/components/blocks/Figure.astro
+++ b/src/components/blocks/Figure.astro
@@ -11,6 +11,7 @@
 * @param {ImageFit} [fit] - object-fit styles for the image
 * @param {Frame} [frame='None'] - a frame or device for the image
 * @param {number} [maxHeight] - constrain the image to a certain height, in vh units
+* @param {boolean} [useImageAspectRato=false] - for a device, use the image's own aspect ratio instead of of the default (e.g. 4/3 for a tablet)
  */
 
 // --- styles ---
@@ -42,6 +43,7 @@ const {
 	class: className,
 	fit,
 	maxHeight,
+	useImageAspectRatio,
 } = Astro.props;
 ---
 
@@ -56,6 +58,7 @@ const {
 					{frame}
 					{maxHeight}
 					{source}
+					{useImageAspectRatio}
 				/>
 			)}
 		</slot>

--- a/src/components/blocks/ImageGallery.astro
+++ b/src/components/blocks/ImageGallery.astro
@@ -41,6 +41,7 @@ const {
 	fitImages = 'default',
 	frame = 'None',
 	gutter = 'xnarrow',
+	useImageAspectRatio = false,
 } = Astro.props;
 ---
 
@@ -61,6 +62,7 @@ const {
 					fit={fitImages}
 					{border}
 					{frame}
+					{useImageAspectRatio}
 				/>
 			</RevealOnScroll>
 		))}

--- a/src/components/elements/ImageFrame.astro
+++ b/src/components/elements/ImageFrame.astro
@@ -1,4 +1,16 @@
 ---
+/**
+ * Image Frame component
+ * - Display an image with a specific frame
+ *
+ * @param {ImageField} source - image source data from Prismic
+ * @param {boolean} [border] - flag to display a border
+ * @param {ImageField} [darkModeSource] - optional dark mode image source
+ * @param {ImageFit} [fit] - how to fit the image within its frame/container
+ * @param {Frame} [frame] - the frame/device to display around the image
+ * @param {number} [maxHeight] - how tall the image is allowed to be, in vh units
+ * @param {boolean} [useImageAspectRato=false] - for a device, use the image's own aspect ratio instead of of the default (e.g. 4/3 for a tablet)
+ */
 // child components
 import Image from '@components/elements/Image.astro';
 import ImageFrameDevice from '@components/elements/ImageFrameDevice.astro';
@@ -8,15 +20,6 @@ import ImageFrameWall from '@components/elements/ImageFrameWall.astro';
 import type { ImageField } from '@prismicio/types';
 import type { Frame, ImageFit } from '@lib/types';
 
-export interface Props {
-	source: ImageField;
-	border?: boolean;
-	darkModeSource?: ImageField;
-	fit?: ImageFit;
-	frame?: Frame;
-	maxHeight?: number;
-}
-
 const {
 	source,
 	border,
@@ -24,7 +27,8 @@ const {
 	fit,
 	frame,
 	maxHeight,
-} = Astro.props as Props;
+	useImageAspectRatio,
+} = Astro.props;
 
 const imageComponents = {
 	'None': {
@@ -71,6 +75,7 @@ const imageComponents = {
 			darkModeSource,
 			maxHeight,
 			source,
+			useImageAspectRatio,
 		},
 	},
 	'Tablet (landscape)': {
@@ -80,6 +85,7 @@ const imageComponents = {
 			darkModeSource,
 			maxHeight,
 			source,
+			useImageAspectRatio,
 		},
 	},
 	'Tablet (portrait)': {
@@ -89,6 +95,7 @@ const imageComponents = {
 			darkModeSource,
 			maxHeight,
 			source,
+			useImageAspectRatio,
 		},
 	},
 };

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -141,7 +141,6 @@ const styleList = [
 			margin-inline: auto;
 			max-height: calc(var(--max-height) * 1vh);
 			max-height: calc(var(--max-height) * 1svh);
-			max-width: 100%;
 			overflow: hidden;
 			padding: var(--bezel-width-y) var(--bezel-width-x);
 			position: relative;

--- a/src/components/elements/ImageFrameDevice.astro
+++ b/src/components/elements/ImageFrameDevice.astro
@@ -1,24 +1,30 @@
 ---
-// Add a frame around content that looks like a mobile device
-// -> Phone, Tablet (horizontal and vertical)
+/**
+ * Image Frame: Device component
+ * - Add a frame around content that looks like a mobile device
+ *
+ * @param {ImageField} source - the primary image
+ * @param {ImageField} [darkModeSource] - the image used for dark mode
+ * @param {boolean} [useImageAspectRatio=false] - use the image's own aspect ratio
+ * 	- instead of a standard device aspect ratio (e.g. 4/3 for tablets)
+ * @param {string} [class] - classes to append to the container
+ * @param {string} [el='div'] - HTML tag for the container element
+ * @param {number} [maxHeight] - how tall the image is allowed to be, in vh units
+ * @param {Frame} [type] - the device 'frame' to display
+ */
 
-// components
+// --- assets ---
+import '@styles/tokens/borders.css';
+import '@styles/tokens/elevation.css';
+
+// --- components ---
 import Image from '@components/elements/Image.astro';
 
-// types
+// --- types ---
 import type { Frame } from '@lib/types';
 import type { ImageField } from '@prismicio/types';
 
-export interface Props {
-	source: ImageField;
-	darkModeSource?: ImageField;
-	useImageAspectRatio?: boolean;
-	class?: string;
-	el?: string;
-	maxHeight?: number;
-	type?: Frame;
-};
-
+// --- props ---
 const {
 	source,
 	class: className = '',
@@ -27,36 +33,88 @@ const {
 	maxHeight = 75,
 	type = 'Tablet (landscape)',
 	useImageAspectRatio = false,
-} = Astro.props as Props;
+} = Astro.props;
 
+// styling data for each device type
+// - keys are the values from the Prismic 'frame' field
 const types = {
-	'Phone': 'phone',
-	'Tablet (landscape)': 'tablet-landscape',
-	'Tablet (portrait)': 'tablet-portrait',
+	'Phone': {
+		className: 'phone',
+		defaultAspectRatio: '1/2.05',
+		bezel: {
+			radius: { x: 10, y: 5 },
+			width: { x: 3.5, y: 11 },
+		},
+		screen: {
+			radius: { x: 2, y: 1 },
+		},
+	},
+	'Tablet (landscape)': {
+		className: 'tablet-landscape',
+		defaultAspectRatio: '4/3',
+		bezel: {
+			radius: { x: 4.5, y: 6 },
+			width: { x: 5, y: 5 },
+		},
+		screen: {
+			radius: { x: 0.75, y: 1 },
+		},
+	},
+	'Tablet (portrait)': {
+		className: 'tablet-portrait',
+		defaultAspectRatio: '3/4',
+		bezel: {
+			radius: { x: 6, y: 6 },
+			width: { x: 5, y: 5 },
+		},
+		screen: {
+			radius: { x: 1, y: 0.75 },
+		},
+	},
 };
+
+const device = types[type];
+
+/**
+ * Calculate the aspect ratio of the frame/container from the image dimensions
+ * @param {ImageField} source - the image data from Prismic
+ * @returns {string} - aspect ratio CSS value, e.g. '4/3'
+ */
+function calculateOuterAspectRatio(source) {
+	const { width, height } = source.dimensions;
+	// calculate the padding percentage in each axis
+	const paddingX = width * (device.bezel.width.x / 100);
+	const paddingY = width * (device.bezel.width.y / 100);
+	// find the dimensions with the padding for the bezel
+	const autoAspectX = width + paddingX;
+	const autoAspectY = height + paddingY;
+	// create the aspect ratio CSS string
+	return `${autoAspectX} / ${autoAspectY}`;
+}
 
 const El = el;
 
 const classList = [
 	'device-frame',
-	types[type] || '',
+	device.className || '',
 	className,
 ].join(' ');
 
-function calculateOuterAspectRatio(source) {
-	const { width, height } = source.dimensions;
-	const autoAspectX = width + (width * 0.035);
-	const autoAspectY = height + (width * 0.11) + 16;
-	return `${autoAspectX} / ${autoAspectY}`;
-}
+const styleList = [
+	maxHeight ? `--max-height: ${maxHeight};` : '',
+	useImageAspectRatio
+		? `--aspect-ratio: ${calculateOuterAspectRatio(source)};`
+		: `--aspect-ratio: ${device.defaultAspectRatio};`,
+	`--bezel-radius: ${device.bezel.radius.x}% / ${device.bezel.radius.y}%;`,
+	`--screen-radius: ${device.screen.radius.x}% / ${device.screen.radius.y}%;`,
+	`--bezel-width-x: ${device.bezel.width.x}%;`,
+	`--bezel-width-y: ${device.bezel.width.y}%;`,
+].join('');
 ---
 
 <El
 	class={classList}
-	style={[
-		maxHeight ? `--max-height: ${maxHeight};` : '',
-		useImageAspectRatio ? `--aspect-ratio: ${calculateOuterAspectRatio(source)};` : '',
-	].join(' ')}
+	style={styleList}
 >
 	<div class="wrapper">
 		<slot>
@@ -67,25 +125,20 @@ function calculateOuterAspectRatio(source) {
 
 <style>
 	/*
-		- only display the device frame if aspect-ratio supported
-		- otherwise it will look super wonky
+		Only display the device frame if aspect-ratio is supported
+		otherwise it will look super wonky.
 		- default/fallback is showing the image by itself
 	*/
 	@supports (aspect-ratio: 1/2) {
 		.device-frame {
-			/* use percentage units for the bezel and corners, so they scale fluidly with the image and aspect ratio */
-			--aspect-ratio: 4/3;
-			--bezel-radius: 4.5% / 6%;
-			--bezel-width-x: 5%;
-			--bezel-width-y: 5%;
-			--screen-radius:  0.75% / 1%;
-
 			aspect-ratio: var(--aspect-ratio);
 			background-color: var(--color-island);
+			border: var(--border-solid);
 			border-radius: var(--bezel-radius);
-			border: 1px solid var(--color-border);
-			box-shadow: 0 0.125em 0.25em var(--color-shadow);
+			box-shadow: var(--elevation-medium);
+			justify-content: center;
 			display: flex;
+			margin-inline: auto;
 			max-height: calc(var(--max-height) * 1vh);
 			max-height: calc(var(--max-height) * 1svh);
 			max-width: 100%;
@@ -98,8 +151,8 @@ function calculateOuterAspectRatio(source) {
 			/* set the inner aspect ratio and crop the image
 			 * - Firefox bug distorts the image if we use object-fit and position here
 			*/
+			border: var(--border-solid);
 			border-radius: var(--screen-radius);
-			border: 1px solid var(--color-border);
 			overflow: hidden;
 		}
 
@@ -109,23 +162,7 @@ function calculateOuterAspectRatio(source) {
 			}
 		}
 
-		.device-frame.tablet-landscape {
-			--aspect-ratio: 4/3;
-			--screen-radius: 1%;
-		}
-
-		.device-frame.tablet-portrait {
-			--aspect-ratio: 3/4;
-			--bezel-radius: 6%;
-		}
-
 		.device-frame.phone {
-			--aspect-ratio: 1/2.05;
-			--bezel-radius: 10% / 5%;
-			--bezel-width-x: 3.5%;
-			--bezel-width-y: 11%;
-			--screen-radius: 2% / 1%;
-
 			box-shadow: var(--elevation-low);
 		}
 	}

--- a/src/components/elements/ImageFrameWall.astro
+++ b/src/components/elements/ImageFrameWall.astro
@@ -106,8 +106,8 @@ const styleList = arrayToPunctatedString([
 	.picture.matte,
 	.picture.frame,
 	.picture.panel {
-		/* don't use a global variable for the frame color because it should always be dark black, tinted very slightly to the current key hue */
-		--frame-color: oklch(30% 0.008 var(--base-h));
+		/* don't use a global token for the frame color because it should always be dark black, tinted very slightly to the current key hue */
+		--frame-color: oklch(from var(--color-surface) 30% 0.008 h);
 		--shadow-color: var(--color-shadow);
 
 		align-items: center;
@@ -130,7 +130,7 @@ const styleList = arrayToPunctatedString([
 
 	.picture.panel {
 		/* the 'inset' area of a panel should always be very dark */
-		--matte-color: oklch(20% 0.008 var(--base-h));
+		--matte-color: oklch(from var(--color-surface) 20% 0.008 h);
 
 		box-shadow: var(--elevation-high);
 	}
@@ -147,7 +147,7 @@ const styleList = arrayToPunctatedString([
 		.picture.matte,
 		.picture.frame,
 		.picture.panel {
-			--frame-color: oklch(15% 0.008 var(--base-h));
+			--frame-color: oklch(from var(--color-surface) 15% 0.008 h);
 		}
 
 		/* a darker matte feels better with the images against a dark surface */

--- a/src/pages/design/[year]/[uid].astro
+++ b/src/pages/design/[year]/[uid].astro
@@ -1,4 +1,22 @@
 ---
+/**
+ * Design case study page
+ *
+ * @param {Slice[]} body - block list
+ * @param {string} client - client's name
+ * @param {string} role - my specific role on this project
+ * @param {NumberField} startDate - year the project started, YYYY
+ * @param {TitleField} title - The project's title
+ * @param {string} [agency] - an agency I worked for/subcontracted to
+ * @param {Collaborator[]} [collaborators] - list of collaborator references
+ * @param {GroupField} [contributions] - list of jobs/tasks, e.g. 'art direction'
+ * @param {NumberField} [endDate] - year the project ended, YYYY
+ * @param {PaginationLink} [next] - data for the next post in the collection
+ * @param {SEOContent} [seo] - SEO data from Prismic
+ * @param {TitleField} [subtitle] - The project's subtitle
+ * @param {Theme} [theme] - Color theme data
+ */
+
 // assets
 import '@styles/tokens/spacing.css';
 import '@styles/tokens/contentWidth.css';
@@ -23,12 +41,11 @@ import prismic from '@lib/prismic';
 import type {
 	GroupField,
 	NumberField,
-	RelationField,
 	Slice,
 	TitleField,
 } from '@prismicio/types';
 
-import type { PaginationLink, SEOContent } from '@lib/types';
+import type { PaginationLink, SEOContent, Theme } from '@lib/types';
 
 export type Contribution = {
 	task: string,
@@ -38,21 +55,6 @@ export type Collaborator = {
 	name: string,
 	website: string,
 };
-
-export interface Props {
-	agency: string;
-	body: Slice[];
-	client: string;
-	role: string;
-	startDate: NumberField;
-	title: TitleField;
-	collaborators?: Collaborator[];
-	contributions?: GroupField;
-	endDate?: NumberField;
-	next?: PaginationLink;
-	seo?: SEOContent;
-	subtitle?: TitleField;
-}
 
 export async function getStaticPaths() {
 	const projects = await prismic.getAllByType('design_project', {
@@ -83,7 +85,10 @@ export async function getStaticPaths() {
 		const {
 			start_date: startDate,
 			end_date: endDate,
-			collaborators
+			collaborators,
+			preset_theme,
+			base_hue,
+			body1: themes,
 		} = data;
 
 		return {
@@ -100,6 +105,11 @@ export async function getStaticPaths() {
 					image: data.seo_image?.url,
 					imageAlt: data.seo_image?.alt,
 					title: data.seo_title || prismicHelpers.asText(data.title),
+				},
+				theme: {
+					name: preset_theme,
+					hue: base_hue,
+					custom: themes,
 				},
 				collaborators: collaborators.map(
 					({ collaborator }) => collaborator.data
@@ -126,7 +136,8 @@ const {
 	endDate,
 	next,
 	seo,
-} = Astro.props as Props;
+	theme,
+} = Astro.props;
 
 const credits = [
 	{
@@ -165,6 +176,7 @@ const credits = [
 	pageTitle={prismicHelpers.asText(title)}
 	path="design"
 	{seo}
+	{theme}
 >
 	<MainNav segment="design" />
 	<main>
@@ -220,8 +232,7 @@ const credits = [
 	.headline {
 		max-width: var(--content-width-xwide);
 		margin-inline: auto;
-		padding-block-start: var(--space-wide);
-		padding-block-end: var(--space-xwide);
+		padding-block: var(--space-xwide);
 		text-align: center;
 		display: flex;
 		flex-direction: column;

--- a/src/pages/pictures.astro
+++ b/src/pages/pictures.astro
@@ -108,8 +108,6 @@ const seriesList = picturesData
 
 		if (result.find((s) => s.uid === uid)) return result;
 
-		console.log(uid, matteColor, wallColor);
-
 		result.push({
 			// if all the pictures in the series have the same aspect ratio, leave this prop undefined so the grid boxes will be whatever shape the pictures are
 			// if not, use the default aspect ratio so the grid boxes will be the same shape and will constrain the different-shaped pictures to equal areas


### PR DESCRIPTION
## Description
- Instead of forcing default device aspect ratios (e.g. 4/3 for a tablet), allow the frame to adopt the image's own aspect ratio
- Helpful for screenshots that don't exactly match the default aspect ratios

## Tasks
- [Automatic aspect ratios on device frames](https://app.todoist.com/app/task/automatic-aspect-ratios-on-device-frames-6XGM5xQXP7Q555Jw)
